### PR TITLE
feat: add warning for integer/binary variable relaxation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-170%20passing-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-174%20passing-brightgreen.svg)](tests/)
 
 Write optimization problems in natural Python. Optyx handles the gradients, constraints, and solver plumbing for you.
 

--- a/docs/api/expressions.qmd
+++ b/docs/api/expressions.qmd
@@ -22,6 +22,11 @@ x = Variable(name, lb=None, ub=None, domain="continuous")
 | `ub` | `float | None` | Upper bound | `None` (unbounded) |
 | `domain` | `str` | One of `"continuous"`, `"integer"`, `"binary"` | `"continuous"` |
 
+::: {.callout-warning}
+## Integer/Binary Domains Relaxed
+The `"integer"` and `"binary"` domains are accepted but **relaxed to continuous values** when using the SciPy solver backend. A runtime warning is emitted when this occurs. For true mixed-integer programming, consider using PuLP or Pyomo.
+:::
+
 ### Properties
 
 | Property | Type | Description |

--- a/src/optyx/solvers/scipy_solver.py
+++ b/src/optyx/solvers/scipy_solver.py
@@ -54,6 +54,18 @@ def solve_scipy(
             message="Problem has no variables",
         )
     
+    # Warn if any variables have non-continuous domains
+    non_continuous = [v for v in variables if v.domain != "continuous"]
+    if non_continuous:
+        names = ", ".join(v.name for v in non_continuous)
+        warnings.warn(
+            f"Variables [{names}] have integer/binary domains but will be relaxed "
+            f"to continuous. SciPy solver does not support integer programming. "
+            f"For true MIP, consider PuLP or Pyomo.",
+            UserWarning,
+            stacklevel=3,
+        )
+    
     # Build objective function
     obj_expr = problem.objective
     if problem.sense == "maximize":


### PR DESCRIPTION
## Summary
Adds a runtime warning when solving problems that contain integer or binary variables, informing users that these are relaxed to continuous values by the SciPy solver.

## Changes
- **src/optyx/solvers/scipy_solver.py**: Added `UserWarning` before solving when non-continuous variables are detected
- **docs/api/expressions.qmd**: Added callout warning about integer/binary domain relaxation
- **tests/test_solvers.py**: Added 4 tests for warning behavior
- **README.md**: Updated test badge from 170 to 174 tests

## Example Warning
```
UserWarning: Variables [x, y] have integer/binary domains but will be relaxed 
to continuous. SciPy solver does not support integer programming. 
For true MIP, consider PuLP or Pyomo.
```

## Impact
- Users are immediately informed when behavior differs from expectation
- Reduces confusion and potential bug reports
- Documents the path forward (alternative MIP solvers)

Closes #15