### PR TITLE
feat: Handle derivative singularities at x=0 for abs, sqrt, log

### DIFF
--- a/docs/api/autodiff.qmd
+++ b/docs/api/autodiff.qmd
@@ -230,9 +230,30 @@ Optyx implements standard differentiation rules:
 | $e^x$ | $e^x$ |
 | $\ln(x)$ | $1/x$ |
 | $\sqrt{x}$ | $1/(2\sqrt{x})$ |
+| $\lvert x \rvert$ | $x/\lvert x \rvert$ |
 | $\tanh(x)$ | $1 - \tanh^2(x)$ |
 | $\sinh(x)$ | $\cosh(x)$ |
 | $\cosh(x)$ | $\sinh(x)$ |
+
+---
+
+## Singularity Handling
+
+Some derivative formulas produce undefined values at certain points:
+
+| Function | Derivative | Singularity |
+|----------|------------|-------------|
+| $\lvert x \rvert$ | $x/\lvert x \rvert$ | $0/0$ → NaN at $x=0$ |
+| $\sqrt{x}$ | $1/(2\sqrt{x})$ | $1/0$ → +Inf at $x=0$ |
+| $\ln(x)$ | $1/x$ | $1/0$ → +Inf at $x=0$ |
+
+**Optyx handles these automatically** when using compiled derivative functions (`compile_gradient`, `compile_jacobian`, `compile_hessian`):
+
+- **NaN** values are replaced with **0.0** (subgradient convention)
+- **+Inf** values are replaced with **+1e16** (large but finite)
+- **-Inf** values are replaced with **-1e16** (large but finite)
+
+This prevents solver crashes while preserving gradient direction. For best results, avoid exact singularities by using appropriate variable bounds (e.g., `lb=1e-6` instead of `lb=0`).
 
 ---
 

--- a/src/optyx/core/autodiff.py
+++ b/src/optyx/core/autodiff.py
@@ -316,7 +316,7 @@ def compile_jacobian(
         A callable that takes a 1D array and returns the Jacobian as a 2D array.
     """
     import numpy as np
-    from optyx.core.compiler import compile_expression
+    from optyx.core.compiler import compile_expression, _sanitize_derivatives
     
     jacobian_exprs = compute_jacobian(exprs, variables)
     m = len(exprs)
@@ -333,7 +333,7 @@ def compile_jacobian(
         for i in range(m):
             for j in range(n):
                 result[i, j] = compiled_elements[i][j](x)
-        return result
+        return _sanitize_derivatives(result)
     
     return jacobian_fn
 
@@ -352,7 +352,7 @@ def compile_hessian(
         A callable that takes a 1D array and returns the Hessian as a 2D array.
     """
     import numpy as np
-    from optyx.core.compiler import compile_expression
+    from optyx.core.compiler import compile_expression, _sanitize_derivatives
     
     hessian_exprs = compute_hessian(expr, variables)
     n = len(variables)
@@ -371,7 +371,7 @@ def compile_hessian(
                 result[i, j] = val
                 if i != j:
                     result[j, i] = val  # Symmetry
-        return result
+        return _sanitize_derivatives(result)
     
     return hessian_fn
 


### PR DESCRIPTION
## Summary
This PR fixes the numerical instability identified in the audit report where derivatives of `abs(x)`, `sqrt(x)`, and `log(x)` produced `NaN` or `Inf` at x=0, potentially crashing solvers.

## Changes
- Add `_sanitize_derivatives` helper in `compiler.py` to replace non-finite values
- Apply sanitization in `compile_gradient`, `compile_jacobian`, `compile_hessian`
- Replacement strategy:
  - `NaN` → `0.0` (subgradient convention for abs(0))
  - `±Inf` → `±1e16` (large but finite, preserves gradient direction)
- Add 6 new tests for singularity handling
- Document singularities and handling in `docs/api/autodiff.qmd`

## Testing
All 185 tests pass.

Fixes #20