### PR TITLE
feat: Add strict mode for integer/binary variable enforcement

### DIFF
--- a/docs/api/problem.qmd
+++ b/docs/api/problem.qmd
@@ -118,17 +118,20 @@ prob.subject_to(constraint)
 Solve the optimization problem.
 
 ```python
-solution = prob.solve(method="SLSQP", x0=None, tol=None, maxiter=None)
+solution = prob.solve(method="SLSQP", strict=False, x0=None, tol=None, maxiter=None)
 ```
 
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `method` | `str` | Solver method | `"SLSQP"` |
+| `strict` | `bool` | Raise error for unsupported features | `False` |
 | `x0` | `np.ndarray | None` | Initial point | Auto-generated |
 | `tol` | `float | None` | Solver tolerance | Solver default |
 | `maxiter` | `int | None` | Maximum iterations | Solver default |
 
 **Returns:** [`Solution`](solution.qmd)
+
+**Raises:** `ValueError` if `strict=True` and the problem contains features the solver cannot handle (e.g., integer/binary variables with SciPy).
 
 **Available methods:**
 
@@ -137,6 +140,25 @@ solution = prob.solve(method="SLSQP", x0=None, tol=None, maxiter=None)
 | `"SLSQP"` | Sequential Least Squares Programming | Equality + Inequality |
 | `"trust-constr"` | Trust-region constrained | Equality + Inequality |
 | `"L-BFGS-B"` | Limited-memory BFGS with bounds | Bounds only |
+
+---
+
+## Strict Mode
+
+Use `strict=True` to enforce that the solver can handle all problem features exactly:
+
+```python
+# Default: warn and relax integer/binary to continuous
+solution = prob.solve()  # Works, but may produce fractional values
+
+# Strict: fail if problem can't be solved exactly
+solution = prob.solve(strict=True)  # Raises ValueError for integer/binary
+```
+
+This is useful for production code where you want to ensure correctness:
+
+- **Prototyping:** Use `strict=False` (default) to quickly test ideas
+- **Production:** Use `strict=True` to catch unsupported configurations early
 
 ---
 

--- a/src/optyx/problem.py
+++ b/src/optyx/problem.py
@@ -138,24 +138,34 @@ class Problem:
         """
         return [(v.lb, v.ub) for v in self.variables]
     
-    def solve(self, method: str = "SLSQP", **kwargs) -> Solution:
+    def solve(
+        self,
+        method: str = "SLSQP",
+        strict: bool = False,
+        **kwargs,
+    ) -> Solution:
         """Solve the optimization problem.
         
         Args:
             method: Solver method. Options: "SLSQP", "trust-constr", "L-BFGS-B".
+            strict: If True, raise ValueError when the problem contains features
+                that the solver cannot handle exactly (e.g., integer/binary
+                variables with SciPy). If False (default), emit a warning and
+                use the best available approximation.
             **kwargs: Additional arguments passed to the solver.
             
         Returns:
             Solution object with results.
             
         Raises:
-            ValueError: If no objective has been set.
+            ValueError: If no objective has been set, or if strict=True and
+                the problem contains unsupported features.
         """
         if self._objective is None:
             raise ValueError("No objective set. Call minimize() or maximize() first.")
         
         from optyx.solvers.scipy_solver import solve_scipy
-        return solve_scipy(self, method=method, **kwargs)
+        return solve_scipy(self, method=method, strict=strict, **kwargs)
     
     def __repr__(self) -> str:
         obj_str = "not set" if self._objective is None else f"{self._sense}"

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -57,6 +57,54 @@ class TestIntegerBinaryWarning:
         assert sol.is_optimal
 
 
+class TestStrictMode:
+    """Tests for strict mode enforcement of integer/binary variables."""
+    
+    def test_strict_mode_raises_for_binary(self):
+        """strict=True should raise ValueError for binary variables."""
+        x = Variable("x", domain="binary")
+        prob = Problem().minimize((x - 0.5)**2)
+        
+        with pytest.raises(ValueError, match="integer/binary domains"):
+            prob.solve(strict=True)
+    
+    def test_strict_mode_raises_for_integer(self):
+        """strict=True should raise ValueError for integer variables."""
+        x = Variable("x", lb=0, ub=10, domain="integer")
+        prob = Problem().minimize((x - 3.7)**2)
+        
+        with pytest.raises(ValueError, match="integer/binary domains"):
+            prob.solve(strict=True)
+    
+    def test_strict_mode_ok_for_continuous(self):
+        """strict=True should not raise for continuous variables."""
+        x = Variable("x")
+        prob = Problem().minimize(x**2)
+        
+        # Should not raise
+        sol = prob.solve(strict=True)
+        assert sol.is_optimal
+    
+    def test_strict_false_still_warns(self):
+        """strict=False (default) should still emit warning."""
+        x = Variable("x", domain="binary")
+        prob = Problem().minimize((x - 0.5)**2)
+        
+        with pytest.warns(UserWarning, match="integer/binary domains"):
+            sol = prob.solve(strict=False)
+        
+        assert sol.is_optimal
+    
+    def test_error_message_includes_variable_names(self):
+        """Error message should list affected variable names."""
+        a = Variable("a", domain="binary")
+        b = Variable("b", domain="integer", lb=0, ub=5)
+        prob = Problem().minimize(a + b)
+        
+        with pytest.raises(ValueError, match=r"\[a, b\]"):
+            prob.solve(strict=True)
+
+
 class TestUnconstrainedOptimization:
     """Tests for unconstrained optimization problems."""
     


### PR DESCRIPTION
## Summary
This PR implements the architectural recommendation from the audit report to add a `strict` mode for handling discrete variables.

## Changes
- Add `strict` parameter to `Problem.solve()` and `solve_scipy()` (default `False`)
- When `strict=True`: Raises `ValueError` if the problem contains integer/binary variables that the SciPy solver cannot enforce.
- When `strict=False` (default): Emits a warning and relaxes variables to continuous (preserving existing behavior).
- Add 5 new tests for strict mode behavior.
- Document the new parameter in `docs/api/problem.qmd`.

## Testing
All 190 tests pass.

Fixes #21