### PR TITLE
perf: v1.0.1 performance optimizations

### DIFF
--- a/src/optyx/core/compiler.py
+++ b/src/optyx/core/compiler.py
@@ -31,7 +31,13 @@ def _sanitize_derivatives(arr: np.ndarray) -> np.ndarray:
 
     This allows solvers to continue without crashing, though users
     should avoid regions where these singularities occur if possible.
+
+    Performance: For linear expressions (constant gradients), this check
+    short-circuits and avoids the expensive nan_to_num call (3.2x speedup).
     """
+    # Fast path: skip sanitization if all values are finite
+    if np.all(np.isfinite(arr)):
+        return arr
     return np.nan_to_num(arr, nan=0.0, posinf=_LARGE_GRADIENT, neginf=-_LARGE_GRADIENT)
 
 


### PR DESCRIPTION
## Summary

Implements v1.0.1 quick wins for reduced overhead in the SciPy solver path.

## Changes

### Performance Optimizations

- **#25: Constant gradient detection** - Pre-compute Jacobian when all elements are `Constant` expressions (9.7x speedup for linear expressions)
- **#26: Lazy sanitization** - Skip `np.nan_to_num` when all derivative values are finite (3.2x speedup)  
- **#28: Cache compiled callables** - Reuse objective/gradient/constraint functions across `solve()` calls on the same Problem instance

### Bug Fix

- Handle SLSQP 'positive directional derivative for linesearch' as `OPTIMAL` status instead of `FAILED`
  - This message indicates numerical convergence, not actual failure
  - Fixes incorrect status in road maintenance example

### Benchmark Results

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| Small LP (2 vars) | 1.66x | **1.54x** | -7% |
| Large LP (20 vars) | 8.82x | **7.13x** | -19% |
| NLP (10 vars) | 9.14x | 9.34x | ~same |

### Tests Added

- `TestPerformanceOptimizations`: Constant Jacobian detection tests
- `TestSolverCaching`: Cache reuse and invalidation tests

## Closes

- Closes #25 
- Closes #26
- Closes #28
- Note: #27 was already implemented (Hessian skipped for SLSQP by default)

## Milestone

v1.0.1