### PR TITLE
feat(vectors): add vectorized constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 **Optimization that reads like Python.**
 
+[![PyPI](https://img.shields.io/pypi/v/optyx.svg)](https://pypi.org/project/optyx/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://github.com/daggbt/optyx/actions/workflows/tests.yml/badge.svg)](https://github.com/daggbt/optyx/actions)
+[![CI](https://github.com/daggbt/optyx/actions/workflows/ci.yml/badge.svg)](https://github.com/daggbt/optyx/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-online-blue.svg)](https://daggbt.github.io/optyx/)
 
 📚 **[Documentation](https://daggbt.github.io/optyx/)** · 🚀 **[Quickstart](https://daggbt.github.io/optyx/getting-started/quickstart.html)** · 💡 **[Examples](https://daggbt.github.io/optyx/examples/portfolio.html)**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "optyx"
-version = "1.1.1"
+version = "1.2.0"
 description = "Intuitive symbolic interface for constrained optimization problems"
 readme = "README.md"
 license = "MIT"

--- a/src/optyx/problem.py
+++ b/src/optyx/problem.py
@@ -97,16 +97,26 @@ class Problem:
         self._invalidate_caches()
         return self
 
-    def subject_to(self, constraint: Constraint) -> Problem:
-        """Add a constraint to the problem.
+    def subject_to(self, constraint: Constraint | list[Constraint]) -> Problem:
+        """Add a constraint or list of constraints to the problem.
 
         Args:
-            constraint: Constraint to add.
+            constraint: Constraint or list of constraints to add.
+                Lists are typically produced by vectorized constraints
+                like `x >= 0` on VectorVariable.
 
         Returns:
             Self for method chaining.
+
+        Example:
+            >>> x = VectorVariable("x", 100)
+            >>> prob.subject_to(x >= 0)  # Adds 100 constraints
         """
-        self._constraints.append(constraint)
+        if isinstance(constraint, list):
+            for c in constraint:
+                self._constraints.append(c)
+        else:
+            self._constraints.append(constraint)
         self._invalidate_caches()
         return self
 

--- a/uv.lock
+++ b/uv.lock
@@ -1565,7 +1565,7 @@ wheels = [
 
 [[package]]
 name = "optyx"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
Implements issue #39 - Vectorized constraints (element-wise >= <= eq)

## Changes
- Add `__le__`, `__ge__`, `eq` methods to `VectorVariable` for element-wise constraints
- Add `__le__`, `__ge__`, `eq` methods to `VectorExpression` for expression constraints
- Add `_vector_constraint()` helper for creating constraint lists
- Update `Problem.subject_to()` to accept list of constraints
- Fix README badges: add PyPI badge, fix CI workflow reference (was `tests.yml`, now `ci.yml`)
- Bump version to 1.2.0

## Tests
- 17 new tests for vectorized constraints (68 total vector tests)
- All 327 tests pass

## Acceptance Criteria
- [x] `x >= 0` returns list of 100 constraints for 100-element vector
- [x] `x <= upper_bounds` where `upper_bounds` is another vector
- [x] `x.eq(target)` for equality constraints
- [x] `problem.subject_to(x >= 0)` accepts list of constraints
- [x] Constraints correctly reference individual variables

Closes #39