### PR TITLE
feat(vectors): add dot product and L2/L1 norm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/daggbt/optyx"
+Homepage = "https://daggbt.github.io/optyx/"
+Documentation = "https://daggbt.github.io/optyx/"
 Repository = "https://github.com/daggbt/optyx"
+Changelog = "https://github.com/daggbt/optyx/blob/main/CHANGELOG.md"
 Issues = "https://github.com/daggbt/optyx/issues"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Implements issue #40 - Dot product and L2 norm for vectors.

## Changes
- Add `DotProduct` expression for inner product: `x.dot(y)`
- Add `L2Norm` expression for Euclidean norm: `norm(x)`
- Add `L1Norm` expression for Manhattan norm: `norm(x, ord=1)`
- Add `norm()` function with `ord` parameter (1 or 2)
- Add `dot()` method to `VectorVariable` and `VectorExpression`
- Add Documentation and Changelog URLs to `pyproject.toml`

## Tests
- 19 new tests for dot product and norms (87 total vector tests)
- All 346 tests pass

## Acceptance Criteria

### Dot Product
- [x] `x.dot(y)` returns scalar expression
- [x] Evaluates correctly: `[1,2,3] · [4,5,6] = 32`
- [x] Works in objective: `minimize(x.dot(x))` (sum of squares)
- [x] `x.dot(x)` works (self dot product)

### L2 Norm
- [x] `norm(x)` returns L2 norm expression
- [x] Evaluates correctly: `||[3,4]|| = 5`
- [x] `norm(x, ord=1)` returns L1 norm (sum of abs)

Closes #40