### PR TITLE
feat(vectors): add NumPy integration for vectors

### DIFF
--- a/benchmarks/comparison/bench_vs_scipy.py
+++ b/benchmarks/comparison/bench_vs_scipy.py
@@ -265,7 +265,7 @@ class TestScalingComparison:
             print(
                 f"n={n:4d}: Optyx={optyx_timing.mean_ms:.3f}ms, "
                 f"SciPy={scipy_timing.mean_ms:.3f}ms, "
-                f"ratio={optyx_timing.mean_ms/scipy_timing.mean_ms:.2f}x"
+                f"ratio={optyx_timing.mean_ms / scipy_timing.mean_ms:.2f}x"
             )
 
         plot_scaling_comparison(
@@ -315,7 +315,7 @@ class TestScalingComparison:
             print(
                 f"n={n:4d}: Optyx={optyx_timing.mean_ms:.3f}ms, "
                 f"SciPy={scipy_timing.mean_ms:.3f}ms, "
-                f"ratio={optyx_timing.mean_ms/scipy_timing.mean_ms:.2f}x"
+                f"ratio={optyx_timing.mean_ms / scipy_timing.mean_ms:.2f}x"
             )
 
         plot_scaling_comparison(


### PR DESCRIPTION
## Summary
Implements issue #41 - NumPy integration for vectors.

## Changes
- Add `LinearCombination` expression for weighted sums with numpy coefficients
- Add `VectorVariable.from_numpy()` to create vectors matching array size
- Add `VectorVariable.to_numpy(solution)` to extract solution as numpy array
- Add `__rmatmul__` for `numpy_array @ vector` syntax
- Add `__array_ufunc__ = None` to defer numpy operations to Python

## Tests
- 14 new tests for NumPy integration (101 total vector tests)
- All 360 tests pass

## Acceptance Criteria
- [x] `VectorVariable.from_numpy("x", np.array([...]))` creates vector with matching size
- [x] `x.to_numpy(solution)` extracts solution as numpy array
- [x] `LinearCombination(coefficients, vector)` for weighted sums with constant numpy array
- [x] `returns @ weights` syntax works for portfolio-style expressions

## Example
```python
import numpy as np
from optyx import VectorVariable

returns = np.array([0.12, 0.08, 0.10, 0.15])
weights = VectorVariable.from_numpy("w", returns, lb=0, ub=1)

# Portfolio return: returns @ weights
portfolio_return = returns @ weights  # LinearCombination
```

Closes #41