### PR TITLE
perf: pre-compile regex pattern for natural sort key

### DIFF
--- a/src/optyx/problem.py
+++ b/src/optyx/problem.py
@@ -29,6 +29,9 @@ SMALL_PROBLEM_THRESHOLD = 3
 # Threshold for "large" problems where memory-efficient methods are preferred
 LARGE_PROBLEM_THRESHOLD = 1000
 
+# Pre-compiled regex for natural sorting of variable names
+_NUMBER_SPLIT_RE = re.compile(r"(\d+)")
+
 
 def _natural_sort_key(var: Variable) -> tuple:
     """Generate a sort key for natural ordering of variable names.
@@ -45,7 +48,7 @@ def _natural_sort_key(var: Variable) -> tuple:
     """
     name = var.name
     # Split into text and number parts
-    parts = re.split(r"(\d+)", name)
+    parts = _NUMBER_SPLIT_RE.split(name)
     # Convert number parts to integers for proper numeric sorting
     return tuple(int(p) if p.isdigit() else p for p in parts)
 


### PR DESCRIPTION
Add `_NUMBER_SPLIT_RE` module-level compiled regex pattern instead of calling `re.split()` with a pattern string on every sort comparison. Reduces function call overhead in O(N log N) sorting operations.

## Changes
- Add `_NUMBER_SPLIT_RE = re.compile(r"(\d+)")` at module level
- Update `_natural_sort_key()` to use pre-compiled pattern

## Testing
- All problem tests pass (31 tests)