### PR TITLE
perf: initialize _hash attribute in core expression __init__ methods

### DIFF
--- a/src/optyx/core/expressions.py
+++ b/src/optyx/core/expressions.py
@@ -195,6 +195,7 @@ class Constant(Expression):
     __slots__ = ("value",)
 
     def __init__(self, value: float | int | ArrayLike) -> None:
+        self._hash = None
         self.value = np.asarray(value) if not isinstance(value, (int, float)) else value
 
     def evaluate(
@@ -298,6 +299,7 @@ class BinaryOp(Expression):
         right: Expression,
         op: Literal["+", "-", "*", "/", "**"],
     ) -> None:
+        self._hash = None
         self.left = left
         self.right = right
         self.op = op
@@ -400,6 +402,7 @@ class UnaryOp(Expression):
                 operator=op,
                 context="unary expression",
             )
+        self._hash = None
         self.operand = operand
         self.op = op
         self._numpy_func = self._OPS[op]


### PR DESCRIPTION
Initialize `_hash = None` in Constant, BinaryOp, and UnaryOp `__init__` methods. These are the most frequently created expression types and benefit from having the slot pre-initialized.

The base `__hash__` method keeps the `hasattr()` check for compatibility with other Expression subclasses (in vectors.py, matrices.py) that don't initialize `_hash` explicitly.

## Changes
- Add `self._hash = None` in `Constant.__init__()`
- Add `self._hash = None` in `BinaryOp.__init__()`
- Add `self._hash = None` in `UnaryOp.__init__()`

## Testing
- All expression tests pass (46 tests)
- All vector gradient tests pass (89 tests)