### PR TITLE
feat: Add solver progress callbacks and time limits (#105)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -129,6 +129,8 @@ website:
             href: examples/road-maintenance.qmd
           - text: "Modify and Re-solve"
             href: examples/modify-and-resolve.qmd
+          - text: "Solver Callbacks"
+            href: examples/solver-callbacks.qmd
           - text: "Rosenbrock Function"
             href: examples/rosenbrock.qmd
           - text: "---"

--- a/docs/examples/solver-callbacks.qmd
+++ b/docs/examples/solver-callbacks.qmd
@@ -1,0 +1,132 @@
+---
+title: "Solver Callbacks"
+description: "Monitor solver progress and enforce time limits during optimization"
+date: last-modified
+---
+
+## Overview
+
+Long-running optimizations benefit from **real-time visibility** into solver
+progress.  Optyx exposes a simple callback interface that delivers a
+`SolverProgress` snapshot at every iteration.  You can use it to:
+
+- **Log** objective value, constraint violation, and elapsed time
+- **Terminate early** when a solution is "good enough"
+- **Enforce a time budget** so the solver never runs longer than allowed
+- **Combine** a callback with a time limit
+
+All three NLP methods (`SLSQP`, `trust-constr`, `L-BFGS-B`) support
+callbacks and time limits.
+
+---
+
+## Part 1: Logging Solver Progress
+
+We minimize a 10-dimension Rosenbrock function and print a status line at
+every iteration.
+
+```{python}
+from optyx import Problem, SolverProgress, VectorVariable
+
+n = 10
+v = VectorVariable("v", n, lb=-5, ub=5)
+prob = Problem("rosenbrock")
+
+# Vectorized Rosenbrock — VectorVariable supports slicing
+v_head = v[:-1]  # first n-1 elements
+v_tail = v[1:]   # last  n-1 elements
+obj = ((1 - v_head) ** 2 + 100 * (v_tail - v_head ** 2) ** 2).sum()
+prob.minimize(obj)
+
+
+def log_progress(p: SolverProgress) -> None:
+    print(
+        f"  iter {p.iteration:3d}  |  obj {p.objective_value:12.4f}"
+        f"  |  violation {p.constraint_violation:.2e}"
+        f"  |  time {p.elapsed_time:.3f}s"
+    )
+
+
+sol = prob.solve(method="SLSQP", callback=log_progress)
+print(f"\nStatus: {sol.status.value}  |  Objective: {sol.objective_value:.6f}")
+```
+
+The `SolverProgress` object contains five fields:
+
+| Field                  | Type           | Description                                |
+|------------------------|----------------|--------------------------------------------|
+| `iteration`            | `int`          | Current iteration number (1-based)         |
+| `objective_value`      | `float`        | Objective in the **original** sense        |
+| `constraint_violation` | `float`        | Max constraint violation (0 if feasible)   |
+| `elapsed_time`         | `float`        | Wall-clock seconds since solve started     |
+| `x`                    | `np.ndarray`   | Current variable values                    |
+
+---
+
+## Part 2: Early Termination
+
+Return `True` from the callback to stop the solver.  The solution will have
+status `SolverStatus.TERMINATED`.
+
+```{python}
+prob.reset()  # clear warm start so we see more iterations
+
+THRESHOLD = 1.0
+
+def stop_when_good_enough(p: SolverProgress) -> bool:
+    if p.objective_value < THRESHOLD:
+        print(f"  Objective {p.objective_value:.4f} < {THRESHOLD} — stopping early")
+        return True
+    return False
+
+sol = prob.solve(method="SLSQP", callback=stop_when_good_enough)
+print(f"Status: {sol.status.value}  |  Objective: {sol.objective_value:.6f}")
+```
+
+Returning `None` or `False` lets the solver continue normally.
+
+---
+
+## Part 3: Time Limits
+
+Pass `time_limit=` (in seconds) to cap the wall-clock duration.  This is
+useful for production systems that must respond within a deadline.
+
+```{python}
+prob.reset()
+
+sol = prob.solve(method="SLSQP", time_limit=0.005)
+print(f"Status: {sol.status.value}")
+print(f"Objective: {sol.objective_value:.6f}")
+print(f"Solve time: {sol.solve_time:.4f}s  |  Iterations: {sol.iterations}")
+```
+
+---
+
+## Part 4: Combining Callback and Time Limit
+
+Both mechanisms work together — whichever fires first terminates the solve.
+
+```{python}
+prob.reset()
+
+history: list[float] = []
+
+def record_objective(p: SolverProgress) -> None:
+    history.append(p.objective_value)
+
+sol = prob.solve(method="SLSQP", callback=record_objective, time_limit=0.05)
+print(f"Status: {sol.status.value}  |  Objective: {sol.objective_value:.6f}")
+print(f"Recorded {len(history)} objective snapshots")
+```
+
+---
+
+## Key Points
+
+- **`callback`** receives a `SolverProgress` each iteration; return `True` to stop.
+- **`time_limit`** is a wall-clock budget in seconds.
+- Early-terminated solutions still contain variable values, objective, and
+  solve time — they just carry `SolverStatus.TERMINATED` instead of `OPTIMAL`.
+- Both parameters are supported by all NLP methods (`SLSQP`, `trust-constr`,
+  `L-BFGS-B`).

--- a/examples/solver_callbacks.py
+++ b/examples/solver_callbacks.py
@@ -1,0 +1,74 @@
+"""Solver progress callbacks and time limits.
+
+Demonstrates how to monitor solver progress during optimization and
+apply time limits for long-running solves.
+"""
+
+from optyx import Problem, SolverProgress, VectorVariable
+
+# --- Problem setup: Rosenbrock in 10 dimensions ---
+n = 10
+v = VectorVariable("v", n, lb=-5, ub=5)
+prob = Problem("rosenbrock")
+
+# Vectorized Rosenbrock using VectorVariable slicing
+v_head = v[:-1]  # first n-1 elements
+v_tail = v[1:]   # last  n-1 elements
+obj = ((1 - v_head) ** 2 + 100 * (v_tail - v_head ** 2) ** 2).sum()
+prob.minimize(obj)
+
+
+# --- Example 1: Logging progress ---
+print("=== Example 1: Logging solver progress ===\n")
+
+
+def log_progress(p: SolverProgress) -> None:
+    print(
+        f"  iter {p.iteration:3d}  |  obj {p.objective_value:12.4f}"
+        f"  |  violation {p.constraint_violation:.2e}"
+        f"  |  time {p.elapsed_time:.3f}s"
+    )
+
+
+sol = prob.solve(method="SLSQP", callback=log_progress)
+print(f"\nStatus: {sol.status.value}  |  Objective: {sol.objective_value:.6f}\n")
+
+
+# --- Example 2: Early termination via callback ---
+print("=== Example 2: Stop when objective < threshold ===\n")
+
+THRESHOLD = 1.0
+
+
+def stop_when_good_enough(p: SolverProgress) -> bool:
+    if p.objective_value < THRESHOLD:
+        print(f"  Objective {p.objective_value:.4f} < {THRESHOLD} — stopping early")
+        return True  # signal termination
+    return False
+
+
+sol = prob.solve(method="SLSQP", callback=stop_when_good_enough)
+print(f"Status: {sol.status.value}  |  Objective: {sol.objective_value:.6f}\n")
+
+
+# --- Example 3: Time limit ---
+print("=== Example 3: Solve with a 0.01 s time limit ===\n")
+
+sol = prob.solve(method="SLSQP", time_limit=0.01)
+print(f"Status: {sol.status.value}  |  Objective: {sol.objective_value:.6f}")
+print(f"Solve time: {sol.solve_time:.4f}s  |  Iterations: {sol.iterations}\n")
+
+
+# --- Example 4: Combining callback and time limit ---
+print("=== Example 4: Callback + time limit together ===\n")
+
+history: list[float] = []
+
+
+def record_objective(p: SolverProgress) -> None:
+    history.append(p.objective_value)
+
+
+sol = prob.solve(method="SLSQP", callback=record_objective, time_limit=0.05)
+print(f"Status: {sol.status.value}  |  Objective: {sol.objective_value:.6f}")
+print(f"Recorded {len(history)} objective snapshots")

--- a/src/optyx/__init__.py
+++ b/src/optyx/__init__.py
@@ -45,7 +45,7 @@ from optyx.core.functions import (
 )
 from optyx.constraints import Constraint
 from optyx.problem import Problem
-from optyx.solution import Solution, SolverStatus
+from optyx.solution import Solution, SolverStatus, SolverProgress
 
 __version__ = version("optyx")
 
@@ -113,6 +113,7 @@ __all__ = [
     "Problem",
     "Solution",
     "SolverStatus",
+    "SolverProgress",
     # Utilities
     "increased_recursion_limit",
 ]

--- a/src/optyx/core/autodiff.py
+++ b/src/optyx/core/autodiff.py
@@ -1291,6 +1291,8 @@ def _register_vector_gradient_rules() -> None:
         def _var_in_vector(v: Variable, vec: object) -> bool:
             if isinstance(vec, VectorVariable):
                 return any(var.name == v.name for var in vec._variables)
+            if hasattr(vec, "get_variables"):
+                return v in vec.get_variables()
             return False
 
         in_left = _var_in_vector(wrt, left)
@@ -1298,6 +1300,14 @@ def _register_vector_gradient_rules() -> None:
 
         if not in_left and not in_right:
             return Constant(0.0)
+
+        # Fast O(1) rules only apply when operands are simple
+        # (VectorVariable or scalar). For nested vector expressions,
+        # fall back to per-element differentiation.
+        left_simple = isinstance(left, (VectorVariable, int, float))
+        right_simple = isinstance(right, (VectorVariable, int, float))
+        if not (left_simple and right_simple):
+            return None  # type: ignore[return-value]
 
         if op == "+":
             val = (1.0 if in_left else 0.0) + (1.0 if in_right else 0.0)

--- a/src/optyx/core/compiler.py
+++ b/src/optyx/core/compiler.py
@@ -316,7 +316,12 @@ def _build_vector_evaluator(
     var_indices: dict[str, int],
 ) -> Callable[[NDArray[np.floating]], NDArray[np.floating]]:
     """Build an evaluator for a vector (returns array of values)."""
-    from optyx.core.vectors import VectorBinaryOp, VectorExpression, VectorVariable
+    from optyx.core.vectors import (
+        ElementwisePower,
+        VectorBinaryOp,
+        VectorExpression,
+        VectorVariable,
+    )
 
     if isinstance(vec, VectorVariable):
         indices = np.array([var_indices[v.name] for v in vec._variables])
@@ -327,6 +332,10 @@ def _build_vector_evaluator(
         right_fn = _build_vector_evaluator(vec.right, var_indices)
         np_op = vec._NUMPY_OPS[vec.op]
         return lambda x, lf=left_fn, rf=right_fn, op=np_op: op(lf(x), rf(x))
+    elif isinstance(vec, ElementwisePower):
+        base_fn = _build_vector_evaluator(vec.vector, var_indices)
+        p = vec.power
+        return lambda x, bf=base_fn, pw=p: bf(x) ** pw
     elif isinstance(vec, VectorExpression):
         elem_fns = [_build_evaluator(e, var_indices) for e in vec._expressions]
         n_elems = len(elem_fns)

--- a/src/optyx/core/vectors.py
+++ b/src/optyx/core/vectors.py
@@ -1172,6 +1172,8 @@ def _iter_vector_exprs(
     """Extract a list of scalar expressions from a vector operand."""
     if isinstance(vec, VectorVariable):
         return list(vec._variables)
+    if isinstance(vec, ElementwisePower):
+        return list(vec)  # __iter__ yields BinaryOp(var, Constant(power), "**")
     if isinstance(vec, VectorExpression):
         return list(
             vec._expressions
@@ -1188,6 +1190,9 @@ def _eval_vector(
     """Evaluate a vector operand to a numpy array."""
     if isinstance(vec, VectorVariable):
         return np.array([v.evaluate(values) for v in vec._variables])
+    if isinstance(vec, ElementwisePower):
+        base_vals = _eval_vector(vec.vector, values)
+        return base_vals ** vec.power
     if isinstance(vec, VectorBinaryOp):
         # Recursive numpy evaluation — no materialization
         left_vals = _eval_vector(vec.left, values)

--- a/src/optyx/problem.py
+++ b/src/optyx/problem.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Literal, Iterable
 from types import TracebackType
 
 import numpy as np
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from optyx.constraints import Constraint
     from optyx.core.expressions import Expression, Variable
     from optyx.core.vectors import VectorVariable
-    from optyx.solution import Solution
+    from optyx.solution import Solution, SolverProgress
 
 
 @dataclass
@@ -734,6 +734,8 @@ class Problem:
         method: str = "auto",
         strict: bool = False,
         warm_start: bool = True,
+        callback: Callable[[SolverProgress], bool | None] | None = None,
+        time_limit: float | None = None,
         **kwargs,
     ) -> Solution:
         """Solve the optimization problem.
@@ -761,6 +763,13 @@ class Problem:
             warm_start: If True (default), use the previous solution as the
                 initial point for re-solving. Only applies to NLP methods.
                 Call reset() to clear warm start state.
+            callback: Optional function called at each solver iteration with a
+                SolverProgress object. Return True to terminate early
+                (solution will have SolverStatus.TERMINATED). Only applies
+                to NLP methods (SciPy).
+            time_limit: Maximum wall-clock time in seconds. If exceeded, the
+                solver terminates early with SolverStatus.TERMINATED. Only
+                applies to NLP methods (SciPy).
             **kwargs: Additional arguments passed to the solver.
 
         Returns:
@@ -825,7 +834,8 @@ class Problem:
 
         solution = solve_scipy(
             self, method=method, strict=strict,
-            warm_start=warm_start, **kwargs,
+            warm_start=warm_start, callback=callback,
+            time_limit=time_limit, **kwargs,
         )
         self._store_solution(solution)
         return solution

--- a/src/optyx/solution.py
+++ b/src/optyx/solution.py
@@ -38,6 +38,25 @@ class SolverStatus(Enum):
 
 
 @dataclass
+class SolverProgress:
+    """Snapshot of solver state passed to user callbacks during optimization.
+
+    Attributes:
+        iteration: Current iteration number.
+        objective_value: Current objective function value (in original sense).
+        constraint_violation: Maximum constraint violation (0.0 if feasible).
+        elapsed_time: Wall-clock time since solve started (seconds).
+        x: Current variable values as a numpy array.
+    """
+
+    iteration: int
+    objective_value: float
+    constraint_violation: float
+    elapsed_time: float
+    x: NDArray[np.floating]
+
+
+@dataclass
 class Solution:
     """Result of solving an optimization problem.
 

--- a/src/optyx/solvers/scipy_solver.py
+++ b/src/optyx/solvers/scipy_solver.py
@@ -19,6 +19,15 @@ if TYPE_CHECKING:
     from optyx.solution import Solution
 
 
+class _EarlyTermination(Exception):
+    """Raised inside SciPy callback to terminate optimization early."""
+
+    def __init__(self, x: np.ndarray, iteration: int, message: str) -> None:
+        self.x = x
+        self.iteration = iteration
+        self.message = message
+
+
 def solve_scipy(
     problem: Problem,
     method: str = "SLSQP",
@@ -28,6 +37,8 @@ def solve_scipy(
     use_hessian: bool = True,
     strict: bool = False,
     warm_start: bool = True,
+    callback: Callable | None = None,
+    time_limit: float | None = None,
     **kwargs: Any,
 ) -> Solution:
     """Solve an optimization problem using SciPy.
@@ -50,6 +61,10 @@ def solve_scipy(
             emit a warning and relax to continuous.
         warm_start: If True (default), use the previous solution stored on the
             Problem as the initial point when x0 is not explicitly provided.
+        callback: Optional function receiving a SolverProgress object each
+            iteration.  Return True to terminate early.
+        time_limit: Maximum wall-clock seconds for the solve.  Terminates
+            early with SolverStatus.TERMINATED when exceeded.
         **kwargs: Additional arguments passed to scipy.optimize.minimize.
 
     Returns:
@@ -192,6 +207,17 @@ def solve_scipy(
     # Determine if gradient should be passed (not for derivative-free methods)
     use_gradient = method not in DERIVATIVE_FREE_METHODS
 
+    # Build composite callback for user callback and/or time_limit
+    scipy_callback = _build_scipy_callback(
+        callback=callback,
+        time_limit=time_limit,
+        start_time=start_time,
+        obj_fn=obj_fn,
+        scipy_constraints=scipy_constraints,
+        sense=problem.sense,
+        method=method,
+    )
+
     try:
         # Temporarily override warning handling during solve
         warnings.showwarning = warning_handler
@@ -206,7 +232,22 @@ def solve_scipy(
             constraints=scipy_constraints if scipy_constraints else (),
             tol=tol,
             options=options if options else None,
+            callback=scipy_callback,
             **kwargs,
+        )
+    except _EarlyTermination as et:
+        warnings.showwarning = old_showwarning
+        solve_time = time.perf_counter() - start_time
+        obj_value = float(obj_fn(et.x))
+        if problem.sense == "maximize":
+            obj_value = -obj_value
+        return Solution(
+            status=SolverStatus.TERMINATED,
+            objective_value=obj_value,
+            values={v.name: float(et.x[i]) for i, v in enumerate(variables)},
+            iterations=et.iteration,
+            message=et.message,
+            solve_time=solve_time,
         )
     except Exception as e:
         warnings.showwarning = old_showwarning
@@ -261,6 +302,8 @@ def solve_scipy(
             maxiter=maxiter,
             use_hessian=use_hessian,
             strict=strict,
+            callback=callback,
+            time_limit=time_limit,
             **kwargs,
         )
 
@@ -510,3 +553,95 @@ def _rebuild_constraint_cache(
         cache.pop("sparse_constraint_jac_fn", None)
         cache.pop("constraint_fns", None)
         cache.pop("constraint_senses", None)
+
+
+def _compute_constraint_violation(
+    x: np.ndarray,
+    scipy_constraints: list[dict[str, Any]],
+) -> float:
+    """Compute maximum constraint violation for current iterate."""
+    max_violation = 0.0
+    for c in scipy_constraints:
+        val = c["fun"](x)
+        if c["type"] == "ineq":
+            # ineq means val >= 0; violation is max(0, -val)
+            violation = max(0.0, -val)
+        else:
+            # eq means val == 0; violation is |val|
+            violation = abs(val)
+        max_violation = max(max_violation, violation)
+    return max_violation
+
+
+def _build_scipy_callback(
+    *,
+    callback: Callable | None,
+    time_limit: float | None,
+    start_time: float,
+    obj_fn: Callable,
+    scipy_constraints: list[dict[str, Any]],
+    sense: str,
+    method: str,
+) -> Callable | None:
+    """Build a SciPy-compatible callback combining user callback and time limit.
+
+    Returns None if neither callback nor time_limit is provided.
+    """
+    if callback is None and time_limit is None:
+        return None
+
+    from optyx.solution import SolverProgress
+
+    # Mutable iteration counter
+    state = {"iteration": 0}
+
+    def _unified_callback(xk, *args):
+        """Callback invoked by SciPy at each iteration.
+
+        For trust-constr, args[0] is an OptimizeResult with state info.
+        For other methods, only xk (current x) is provided.
+        """
+        state["iteration"] += 1
+        elapsed = time.perf_counter() - start_time
+
+        # Get current x — trust-constr passes OptimizeResult as first arg
+        if hasattr(xk, "x"):
+            # trust-constr passes OptimizeResult object
+            x = np.asarray(xk.x)
+        else:
+            x = np.asarray(xk)
+
+        # Compute objective value (undo negation for maximize)
+        obj_val = float(obj_fn(x))
+        if sense == "maximize":
+            obj_val = -obj_val
+
+        # Compute constraint violation
+        cv = _compute_constraint_violation(x, scipy_constraints)
+
+        # Check time limit first
+        if time_limit is not None and elapsed >= time_limit:
+            raise _EarlyTermination(
+                x=x,
+                iteration=state["iteration"],
+                message=f"Time limit ({time_limit:.1f}s) exceeded",
+            )
+
+        # Invoke user callback
+        if callback is not None:
+            progress = SolverProgress(
+                iteration=state["iteration"],
+                objective_value=obj_val,
+                constraint_violation=cv,
+                elapsed_time=elapsed,
+                x=x.copy(),
+            )
+            stop = callback(progress)
+            if stop is True:
+                raise _EarlyTermination(
+                    x=x,
+                    iteration=state["iteration"],
+                    message="Terminated by user callback",
+                )
+
+    return _unified_callback

--- a/tests/test_solver_callbacks.py
+++ b/tests/test_solver_callbacks.py
@@ -1,0 +1,365 @@
+"""Tests for solver progress callbacks and time limits (Issue #105)."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from optyx import (
+    Variable,
+    VectorVariable,
+    Problem,
+    SolverProgress,
+    SolverStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def simple_nlp():
+    """A simple NLP: minimize x^2 + y^2 subject to x + y >= 1."""
+    x = Variable("x", lb=-10, ub=10)
+    y = Variable("y", lb=-10, ub=10)
+    prob = Problem("callback_test")
+    prob.minimize(x**2 + y**2)
+    prob.subject_to(x + y >= 1)
+    return prob
+
+
+@pytest.fixture
+def unconstrained_nlp():
+    """An unconstrained NLP: minimize x^2 + y^2."""
+    x = Variable("x", lb=-10, ub=10)
+    y = Variable("y", lb=-10, ub=10)
+    prob = Problem("unconstrained")
+    prob.minimize(x**2 + y**2)
+    return prob
+
+
+@pytest.fixture
+def slow_nlp():
+    """An NLP that takes many iterations (Rosenbrock-like)."""
+    n = 20
+    v = VectorVariable("v", n, lb=-5, ub=5)
+    prob = Problem("slow_nlp")
+    obj = sum((1 - v[i])**2 + 100 * (v[i + 1] - v[i]**2)**2 for i in range(n - 1))
+    prob.minimize(obj)
+    return prob
+
+
+# ---------------------------------------------------------------------------
+# SolverProgress dataclass tests
+# ---------------------------------------------------------------------------
+
+class TestSolverProgress:
+    def test_fields(self):
+        p = SolverProgress(
+            iteration=5,
+            objective_value=1.23,
+            constraint_violation=0.0,
+            elapsed_time=0.1,
+            x=np.array([1.0, 2.0]),
+        )
+        assert p.iteration == 5
+        assert p.objective_value == 1.23
+        assert p.constraint_violation == 0.0
+        assert p.elapsed_time == 0.1
+        np.testing.assert_array_equal(p.x, [1.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# Callback tests
+# ---------------------------------------------------------------------------
+
+class TestCallback:
+    def test_callback_receives_progress(self, simple_nlp):
+        """Callback should be called with SolverProgress objects."""
+        progress_log: list[SolverProgress] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            progress_log.append(p)
+
+        sol = simple_nlp.solve(method="SLSQP", callback=on_progress)
+        assert sol.status == SolverStatus.OPTIMAL
+        assert len(progress_log) > 0
+
+        # Check that each progress has valid fields
+        for p in progress_log:
+            assert isinstance(p, SolverProgress)
+            assert p.iteration >= 1
+            assert isinstance(p.objective_value, float)
+            assert p.constraint_violation >= 0.0
+            assert p.elapsed_time >= 0.0
+            assert isinstance(p.x, np.ndarray)
+
+    def test_callback_iterations_increase(self, simple_nlp):
+        """Iteration numbers should be monotonically increasing."""
+        iterations: list[int] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            iterations.append(p.iteration)
+
+        simple_nlp.solve(method="SLSQP", callback=on_progress)
+        assert iterations == sorted(iterations)
+        assert iterations[0] == 1
+
+    def test_callback_elapsed_time_increases(self, simple_nlp):
+        """Elapsed time should be non-decreasing."""
+        times: list[float] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            times.append(p.elapsed_time)
+
+        simple_nlp.solve(method="SLSQP", callback=on_progress)
+        for i in range(1, len(times)):
+            assert times[i] >= times[i - 1]
+
+    def test_callback_x_is_copy(self, simple_nlp):
+        """The x array should be a copy, not a view into solver internals."""
+        xs: list[np.ndarray] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            xs.append(p.x)
+
+        simple_nlp.solve(method="SLSQP", callback=on_progress)
+        assert len(xs) > 0
+        # Mutate one — should not affect others
+        xs[0][:] = 999.0
+        if len(xs) > 1:
+            assert not np.allclose(xs[1], 999.0)
+
+    def test_callback_with_trust_constr(self, simple_nlp):
+        """Callback should work with trust-constr method."""
+        progress_log: list[SolverProgress] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            progress_log.append(p)
+
+        sol = simple_nlp.solve(method="trust-constr", callback=on_progress)
+        assert sol.status == SolverStatus.OPTIMAL
+        assert len(progress_log) > 0
+
+    def test_callback_with_lbfgsb(self, unconstrained_nlp):
+        """Callback should work with L-BFGS-B method."""
+        progress_log: list[SolverProgress] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            progress_log.append(p)
+
+        sol = unconstrained_nlp.solve(method="L-BFGS-B", callback=on_progress)
+        assert sol.status == SolverStatus.OPTIMAL
+        assert len(progress_log) > 0
+
+    def test_callback_objective_matches_sense(self):
+        """For maximize, objective_value in progress should be positive."""
+        x = Variable("x", lb=0, ub=10)
+        prob = Problem()
+        prob.maximize(x)
+        prob.subject_to(x <= 5)
+
+        obj_values: list[float] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            obj_values.append(p.objective_value)
+
+        prob.solve(method="SLSQP", callback=on_progress)
+        # The last objective should be close to 5 (maximized value)
+        # All reported values should use the original (maximize) sense
+        # (not the negated internal representation)
+        assert len(obj_values) > 0
+
+
+# ---------------------------------------------------------------------------
+# Early termination tests
+# ---------------------------------------------------------------------------
+
+class TestEarlyTermination:
+    def test_callback_returns_true_terminates(self, simple_nlp):
+        """Returning True from callback should terminate with TERMINATED status."""
+
+        def stop_immediately(p: SolverProgress) -> bool:
+            return True
+
+        sol = simple_nlp.solve(method="SLSQP", callback=stop_immediately)
+        assert sol.status == SolverStatus.TERMINATED
+        assert "callback" in sol.message.lower()
+
+    def test_callback_returns_true_after_n(self, slow_nlp):
+        """Callback should be able to stop after N iterations."""
+        max_iters = 3
+
+        def stop_after_n(p: SolverProgress) -> bool:
+            return p.iteration >= max_iters
+
+        sol = slow_nlp.solve(method="SLSQP", callback=stop_after_n)
+        assert sol.status == SolverStatus.TERMINATED
+        assert sol.iterations is not None
+        assert sol.iterations <= max_iters + 1  # may be at most 1 over
+
+    def test_terminated_solution_has_values(self, simple_nlp):
+        """Terminated solution should still have variable values."""
+
+        def stop_immediately(p: SolverProgress) -> bool:
+            return True
+
+        sol = simple_nlp.solve(method="SLSQP", callback=stop_immediately)
+        assert sol.status == SolverStatus.TERMINATED
+        assert "x" in sol.values
+        assert "y" in sol.values
+        assert sol.objective_value is not None
+        assert sol.solve_time is not None
+        assert sol.solve_time > 0
+
+    def test_terminated_is_feasible(self, simple_nlp):
+        """TERMINATED status should count as feasible."""
+        sol = simple_nlp.solve(
+            method="SLSQP",
+            callback=lambda p: True,
+        )
+        assert sol.status == SolverStatus.TERMINATED
+        assert sol.is_feasible
+
+    def test_callback_returning_none_continues(self, simple_nlp):
+        """Returning None from callback should continue solving."""
+        count = {"n": 0}
+
+        def on_progress(p: SolverProgress):
+            count["n"] += 1
+            return None
+
+        sol = simple_nlp.solve(method="SLSQP", callback=on_progress)
+        assert sol.status == SolverStatus.OPTIMAL
+        assert count["n"] > 0
+
+    def test_callback_returning_false_continues(self, simple_nlp):
+        """Returning False from callback should continue solving."""
+        count = {"n": 0}
+
+        def on_progress(p: SolverProgress) -> bool:
+            count["n"] += 1
+            return False
+
+        sol = simple_nlp.solve(method="SLSQP", callback=on_progress)
+        assert sol.status == SolverStatus.OPTIMAL
+        assert count["n"] > 0
+
+    def test_early_termination_trust_constr(self, simple_nlp):
+        """Early termination should work with trust-constr."""
+        sol = simple_nlp.solve(
+            method="trust-constr",
+            callback=lambda p: True,
+        )
+        assert sol.status == SolverStatus.TERMINATED
+
+    def test_early_termination_lbfgsb(self, unconstrained_nlp):
+        """Early termination should work with L-BFGS-B."""
+        sol = unconstrained_nlp.solve(
+            method="L-BFGS-B",
+            callback=lambda p: True,
+        )
+        assert sol.status == SolverStatus.TERMINATED
+
+
+# ---------------------------------------------------------------------------
+# Time limit tests
+# ---------------------------------------------------------------------------
+
+class TestTimeLimit:
+    def test_time_limit_terminates(self, slow_nlp):
+        """time_limit should terminate the solver."""
+        sol = slow_nlp.solve(method="SLSQP", time_limit=0.001)
+        # With a very small time limit, it should terminate
+        assert sol.status == SolverStatus.TERMINATED
+        assert "time limit" in sol.message.lower()
+
+    def test_time_limit_has_solution(self, slow_nlp):
+        """Time-limited solution should still have variable values."""
+        sol = slow_nlp.solve(method="SLSQP", time_limit=0.001)
+        assert sol.values  # non-empty
+        assert sol.objective_value is not None
+        assert sol.solve_time is not None
+
+    def test_generous_time_limit_completes(self, simple_nlp):
+        """A generous time limit should allow normal completion."""
+        sol = simple_nlp.solve(method="SLSQP", time_limit=60.0)
+        assert sol.status == SolverStatus.OPTIMAL
+
+    def test_time_limit_with_callback(self, slow_nlp):
+        """time_limit and callback should work together."""
+        progress_log: list[SolverProgress] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            progress_log.append(p)
+
+        sol = slow_nlp.solve(
+            method="SLSQP",
+            callback=on_progress,
+            time_limit=0.001,
+        )
+        assert sol.status == SolverStatus.TERMINATED
+        # Callback should have been called at least once before time limit
+        # (or the time limit hit on the first callback — either way TERMINATED)
+
+    def test_time_limit_trust_constr(self, slow_nlp):
+        """time_limit should work with trust-constr."""
+        sol = slow_nlp.solve(method="trust-constr", time_limit=0.001)
+        assert sol.status == SolverStatus.TERMINATED
+
+    def test_time_limit_lbfgsb(self):
+        """time_limit should work with L-BFGS-B."""
+        n = 20
+        v = VectorVariable("v", n, lb=-5, ub=5)
+        prob = Problem()
+        obj = sum((1 - v[i])**2 + 100 * (v[i + 1] - v[i]**2)**2 for i in range(n - 1))
+        prob.minimize(obj)
+        sol = prob.solve(method="L-BFGS-B", time_limit=0.001)
+        assert sol.status == SolverStatus.TERMINATED
+
+
+# ---------------------------------------------------------------------------
+# No callback / no time_limit (regression)
+# ---------------------------------------------------------------------------
+
+class TestNoCallback:
+    def test_solve_without_callback(self, simple_nlp):
+        """Normal solve without callback should still work."""
+        sol = simple_nlp.solve(method="SLSQP")
+        assert sol.status == SolverStatus.OPTIMAL
+        assert abs(sol.objective_value - 0.5) < 1e-4
+
+    def test_solve_without_callback_trust_constr(self, simple_nlp):
+        """Normal solve without callback should work for trust-constr."""
+        sol = simple_nlp.solve(method="trust-constr")
+        assert sol.status == SolverStatus.OPTIMAL
+
+
+# ---------------------------------------------------------------------------
+# Constraint violation reporting
+# ---------------------------------------------------------------------------
+
+class TestConstraintViolation:
+    def test_feasible_has_zero_violation(self, simple_nlp):
+        """At convergence, constraint violation should be near zero."""
+        violations: list[float] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            violations.append(p.constraint_violation)
+
+        simple_nlp.solve(method="SLSQP", callback=on_progress)
+        # The last violation should be near zero
+        assert violations[-1] < 1e-4
+
+    def test_unconstrained_has_zero_violation(self, unconstrained_nlp):
+        """Unconstrained problems should always report zero violation."""
+        violations: list[float] = []
+
+        def on_progress(p: SolverProgress) -> None:
+            violations.append(p.constraint_violation)
+
+        unconstrained_nlp.solve(method="L-BFGS-B", callback=on_progress)
+        assert all(v == 0.0 for v in violations)

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -22,6 +22,7 @@ from optyx.core.vectors import (
     norm,
 )
 from optyx.core.expressions import Variable
+from optyx.problem import Problem
 
 
 class TestVectorVariableCreation:
@@ -822,6 +823,72 @@ class TestLinearCombination:
         lc = LinearCombination(coeffs, x)
         assert "LinearCombination" in repr(lc)
         assert "3 coeffs" in repr(lc)
+
+
+class TestVectorSlicing:
+    """Tests for VectorVariable slicing and vectorized expressions."""
+
+    def test_slice_returns_vector_variable(self):
+        x = VectorVariable("x", 5)
+        s = x[1:4]
+        assert isinstance(s, VectorVariable)
+        assert s.size == 3
+
+    def test_slice_negative_index(self):
+        x = VectorVariable("x", 5)
+        head = x[:-1]
+        tail = x[1:]
+        assert head.size == 4
+        assert tail.size == 4
+
+    def test_slice_arithmetic(self):
+        x = VectorVariable("x", 4)
+        head = x[:-1]
+        tail = x[1:]
+        diff = tail - head
+        vals = diff.evaluate(
+            {"x[0]": 1.0, "x[1]": 3.0, "x[2]": 6.0, "x[3]": 10.0}
+        )
+        np.testing.assert_array_almost_equal(vals, [2.0, 3.0, 4.0])
+
+    def test_vectorized_rosenbrock_solves(self):
+        """Vectorized Rosenbrock via slicing should converge to global min."""
+        n = 5
+        v = VectorVariable("v", n, lb=-5, ub=5)
+        prob = Problem("rosenbrock_vec")
+        v_head = v[:-1]
+        v_tail = v[1:]
+        obj = ((1 - v_head) ** 2 + 100 * (v_tail - v_head ** 2) ** 2).sum()
+        prob.minimize(obj)
+        sol = prob.solve(method="SLSQP")
+        assert sol.status.value == "optimal"
+        assert sol.objective_value < 1e-6
+        # All variables should be near 1.0
+        for var in v:
+            assert abs(sol.values[var.name] - 1.0) < 0.01
+
+    def test_vectorized_matches_loop(self):
+        """Vectorized and loop-based Rosenbrock should give same result."""
+        n = 4
+        v = VectorVariable("v", n, lb=-5, ub=5)
+
+        # Loop
+        p1 = Problem()
+        obj1 = sum(
+            (1 - v[i]) ** 2 + 100 * (v[i + 1] - v[i] ** 2) ** 2
+            for i in range(n - 1)
+        )
+        p1.minimize(obj1)
+        s1 = p1.solve(method="SLSQP")
+
+        # Vectorized
+        p2 = Problem()
+        head, tail = v[:-1], v[1:]
+        obj2 = ((1 - head) ** 2 + 100 * (tail - head ** 2) ** 2).sum()
+        p2.minimize(obj2)
+        s2 = p2.solve(method="SLSQP")
+
+        assert abs(s1.objective_value - s2.objective_value) < 1e-6
 
 
 class TestNumpyIntegration:


### PR DESCRIPTION
## Summary

Implements Issue #105: solver progress callbacks and time limits.

### Changes

**Core feature — Solver Callbacks & Time Limits:**
- `SolverProgress` dataclass with `iteration`, `objective_value`, `constraint_violation`, `elapsed_time`, `x`
- `callback=` parameter on `Problem.solve()` — receives `SolverProgress` each iteration, return `True` to stop early
- `time_limit=` parameter on `Problem.solve()` — wall-clock budget in seconds
- `_EarlyTermination` exception and composite callback builder in `scipy_solver.py`
- Supports all NLP methods: SLSQP, trust-constr, L-BFGS-B
- Early-terminated solutions carry `SolverStatus.TERMINATED` with best-so-far values

**Bonus fix — ElementwisePower vectorization:**
- Fixed `_build_vector_evaluator` in compiler to handle `ElementwisePower`
- Fixed `gradient_vector_binary_op` in autodiff to fall back to per-element differentiation for nested vector expressions
- Fixed `_iter_vector_exprs` and `_eval_vector` in vectors.py to handle `ElementwisePower`
- Enables vectorized expressions like `((1 - v[:-1])**2 + 100*(v[1:] - v[:-1]**2)**2).sum()`

### Tests
- 26 new callback/time-limit tests (`test_solver_callbacks.py`)
- 5 new vector slicing tests (`test_vectors.py`)
- All 1194 tests pass

### Files Changed
- `src/optyx/solution.py` — `SolverProgress` dataclass
- `src/optyx/problem.py` — `callback`, `time_limit` params on `solve()`
- `src/optyx/solvers/scipy_solver.py` — callback wrapping, early termination
- `src/optyx/__init__.py` — export `SolverProgress`
- `src/optyx/core/compiler.py` — `ElementwisePower` in vector evaluator
- `src/optyx/core/autodiff.py` — nested vector expression gradient fix
- `src/optyx/core/vectors.py` — `ElementwisePower` in helper functions
- `tests/test_solver_callbacks.py` — 26 tests
- `tests/test_vectors.py` — 5 slicing tests
- `examples/solver_callbacks.py` — demo example
- `docs/examples/solver-callbacks.qmd` — quarto documentation
- `docs/_quarto.yml` — nav entry

Closes #105