### PR TITLE
feat: implement LP format export (#106)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -131,6 +131,8 @@ website:
             href: examples/modify-and-resolve.qmd
           - text: "Solver Callbacks"
             href: examples/solver-callbacks.qmd
+          - text: "LP Export"
+            href: examples/lp-export.qmd
           - text: "Rosenbrock Function"
             href: examples/rosenbrock.qmd
           - text: "---"

--- a/docs/examples/lp-export.qmd
+++ b/docs/examples/lp-export.qmd
@@ -1,0 +1,91 @@
+---
+title: "LP Format Export"
+description: "Export optimization models to the standard LP file format"
+---
+
+Export models to `.lp` files for use with external solvers like CPLEX, Gurobi,
+GLPK, and HiGHS.
+
+## Linear Program
+
+```{python}
+from optyx import Problem, Variable
+
+x = Variable("x", lb=0)
+y = Variable("y", lb=0)
+
+prob = Problem("simple_lp")
+prob.minimize(2 * x + 3 * y)
+prob.subject_to(x + y >= 1)
+prob.subject_to(x - y <= 5)
+
+print(prob.to_lp())
+```
+
+Use `prob.write("model.lp")` to save directly to a file.
+
+## Quadratic Program
+
+Quadratic objectives use the standard `[ ... ] / 2` notation.
+
+```{python}
+from optyx import VectorVariable, quadratic_form
+import numpy as np
+
+w = VectorVariable("w", 3, lb=0, ub=1)
+Q = np.array([[2, 1, 0], [1, 3, 1], [0, 1, 2]], dtype=float)
+c = np.array([1.0, 2.0, 3.0])
+
+prob = Problem("portfolio")
+prob.minimize(quadratic_form(w, Q) + c @ w)
+prob.subject_to(w.sum().eq(1))
+
+print(prob.to_lp())
+```
+
+## Mixed-Integer Program
+
+Integer and binary variables are listed in `Generals` and `Binaries` sections.
+
+```{python}
+from optyx import BinaryVariable, IntegerVariable
+
+x = IntegerVariable("x", lb=0, ub=10)
+y = BinaryVariable("y")
+z = Variable("z", lb=0)
+
+prob = Problem("mip")
+prob.maximize(3 * x + 5 * y + z)
+prob.subject_to(x + 2 * y + z <= 15)
+prob.subject_to(x + y >= 2)
+
+print(prob.to_lp())
+```
+
+## Supported Features
+
+| Feature | Support |
+|---------|---------|
+| Linear objectives | ✓ |
+| Quadratic objectives | ✓ |
+| `<=`, `>=`, `==` constraints | ✓ |
+| Variable bounds | ✓ |
+| Free variables | ✓ |
+| Integer variables (Generals) | ✓ |
+| Binary variables (Binaries) | ✓ |
+| Matrix constraints | ✓ |
+| Sparse matrix constraints | ✓ |
+| Nonlinear objectives | ✗ (raises error) |
+
+## `SolverProgress` Fields
+
+The `Problem.to_lp()` method returns the LP string, while `Problem.write(path)`
+writes it to a file.
+
+```python
+# String representation
+lp_string = prob.to_lp()
+
+# Write to file
+prob.write("model.lp")
+```

--- a/examples/lp_export.py
+++ b/examples/lp_export.py
@@ -1,0 +1,104 @@
+"""LP format export.
+
+Demonstrates how to export optimization models to the standard LP file
+format using Problem.write() and Problem.to_lp().
+"""
+
+from optyx import (
+    BinaryVariable,
+    IntegerVariable,
+    Problem,
+    Variable,
+    VectorVariable,
+    quadratic_form,
+)
+import numpy as np
+import os
+
+# --- Example 1: Simple LP ---
+print("=== Example 1: Simple linear program ===\n")
+
+x = Variable("x", lb=0)
+y = Variable("y", lb=0)
+
+prob = Problem("simple_lp")
+prob.minimize(2 * x + 3 * y)
+prob.subject_to(x + y >= 1)
+prob.subject_to(x - y <= 5)
+
+print(prob.to_lp())
+
+
+# --- Example 2: Quadratic objective ---
+print("=== Example 2: Quadratic program ===\n")
+
+x0 = Variable("x0", lb=0)
+x1 = Variable("x1", lb=0)
+x2 = Variable("x2", lb=0)
+
+prob2 = Problem("dense_qp")
+prob2.minimize(x0 + x1 + x0**2 + x0 * x1 + x1**2 + x1 * x2 + x2**2)
+prob2.subject_to(x0 + 2 * x1 + 3 * x2 >= 4)
+prob2.subject_to(x0 + x1 >= 1)
+
+print(prob2.to_lp())
+
+
+# --- Example 3: Portfolio optimization (QuadraticForm) ---
+print("=== Example 3: Portfolio optimization ===\n")
+
+n_assets = 4
+w = VectorVariable("w", n_assets, lb=0, ub=1)
+
+# Covariance matrix
+cov = np.array([
+    [0.04, 0.006, 0.002, 0.001],
+    [0.006, 0.09, 0.004, 0.003],
+    [0.002, 0.004, 0.01, 0.002],
+    [0.001, 0.003, 0.002, 0.06],
+])
+expected_return = np.array([0.10, 0.15, 0.08, 0.12])
+
+prob3 = Problem("portfolio")
+prob3.minimize(quadratic_form(w, cov))
+prob3.subject_to(w.sum().eq(1))
+prob3.subject_to(expected_return @ w >= 0.10)
+
+print(prob3.to_lp())
+
+
+# --- Example 4: Mixed-integer program ---
+print("=== Example 4: Mixed-integer program ===\n")
+
+# Knapsack-like problem
+items = ["A", "B", "C", "D"]
+from optyx import VariableDict
+
+select = VariableDict("select", items, domain="binary")
+quantity = VariableDict("qty", items, lb=0, ub=10, domain="integer")
+
+weights = {"A": 3, "B": 5, "C": 2, "D": 7}
+values = {"A": 4, "B": 7, "C": 3, "D": 9}
+
+prob4 = Problem("knapsack_mip")
+prob4.maximize(sum(values[i] * select[i] for i in items))
+prob4.subject_to(sum(weights[i] * select[i] for i in items) <= 12)
+
+print(prob4.to_lp())
+
+
+# --- Example 5: Write to file ---
+print("=== Example 5: Writing to file ===\n")
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+
+prob.write(os.path.join(_dir, "simple_lp.lp"))
+print("Wrote simple LP to examples/simple_lp.lp")
+
+prob3.write(os.path.join(_dir, "portfolio.lp"))
+print("Wrote portfolio QP to examples/portfolio.lp")
+
+prob4.write(os.path.join(_dir, "knapsack.lp"))
+print("Wrote knapsack MIP to examples/knapsack.lp")
+
+print("\nDone!")

--- a/src/optyx/analysis.py
+++ b/src/optyx/analysis.py
@@ -1224,6 +1224,51 @@ class LinearProgramExtractor:
 
 
 # =============================================================================
+# Issue #106: Quadratic Coefficient Extraction
+# =============================================================================
+
+
+def extract_quadratic_coefficients(
+    expr: Expression,
+    variables: list[Variable],
+) -> NDArray[np.floating]:
+    """Extract the quadratic coefficient matrix from a quadratic expression.
+
+    For an expression of the form x'Qx + c'x + d, returns the matrix Q
+    such that the quadratic part is sum_{i,j} Q[i,j] * x_i * x_j.
+
+    Args:
+        expr: A quadratic expression.
+        variables: List of variables in the desired ordering.
+
+    Returns:
+        Symmetric (n, n) matrix of quadratic coefficients.
+
+    Raises:
+        NonLinearError: If the expression is not quadratic.
+    """
+    from optyx.io import _is_at_most_quadratic, _collect_quadratic_coefficients
+
+    if not _is_at_most_quadratic(expr):
+        raise NonLinearError(
+            expression=repr(expr)[:100],
+            context="quadratic coefficient extraction",
+            suggestion="Ensure the expression is at most quadratic.",
+        )
+
+    from optyx.io import _collect_quadratic_coefficients
+
+    n = len(variables)
+    var_index = {v.name: i for i, v in enumerate(variables)}
+    Q = np.zeros((n, n), dtype=np.float64)
+    _collect_quadratic_coefficients(expr, var_index, Q, 1.0)
+
+    # Symmetrize: Q_sym = (Q + Q.T) / 2
+    Q_sym = (Q + Q.T) / 2.0
+    return Q_sym
+
+
+# =============================================================================
 # Issue #32: Constraint Helpers and Classification
 # =============================================================================
 

--- a/src/optyx/io.py
+++ b/src/optyx/io.py
@@ -1,0 +1,858 @@
+"""LP format file export for optimization problems.
+
+Exports Problem objects to the standard LP file format, compatible with
+solvers like CPLEX, Gurobi, GLPK, and HiGHS.
+
+LP format reference:
+    https://www.ibm.com/docs/en/icos/22.1.1?topic=cplex-lp-file-format-algebraic-representation
+
+Supported features:
+    - Linear and quadratic objectives
+    - Linear constraints (<=, >=, ==)
+    - Variable bounds
+    - Integer (Generals) and binary (Binaries) variable types
+    - Named constraints
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from optyx.analysis import (
+    is_linear,
+    extract_linear_coefficient,
+    extract_constant_term,
+)
+from optyx.core.errors import InvalidOperationError
+from optyx.core.expressions import (
+    BinaryOp,
+    Constant,
+    Expression,
+    NarySum,
+    UnaryOp,
+    Variable,
+)
+
+if TYPE_CHECKING:
+    from optyx.problem import Problem
+
+
+def _compute_poly_degree(expr: Expression) -> int | None:
+    """Compute the true polynomial degree of an expression.
+
+    Unlike analysis.compute_degree() which treats var*var as non-polynomial
+    (optimized for LP detection), this correctly returns degree 2 for
+    quadratic expressions like x*y or x**2.
+
+    Returns:
+        Integer degree if polynomial, None if non-polynomial.
+    """
+    from optyx.core.matrices import QuadraticForm
+    from optyx.core.vectors import (
+        DotProduct,
+        LinearCombination,
+        VectorSum,
+        VectorVariable,
+        VectorPowerSum,
+        VectorUnarySum,
+        ElementwisePower,
+        ElementwiseUnary,
+    )
+    import numbers
+
+    if isinstance(expr, Constant):
+        return 0
+    if isinstance(expr, Variable):
+        return 1
+
+    # Vector expression types
+    if isinstance(expr, (LinearCombination, VectorSum)):
+        return 1
+    if isinstance(expr, (DotProduct, QuadraticForm)):
+        return 2
+    if isinstance(expr, VectorPowerSum):
+        p = expr.power
+        if isinstance(p, (int, float)) and float(p).is_integer() and p >= 0:
+            return int(p)
+        return None
+    if isinstance(expr, (VectorUnarySum, ElementwiseUnary)):
+        return None
+    if isinstance(expr, ElementwisePower):
+        p = expr.power
+        if isinstance(p, (int, float)) and float(p).is_integer() and p >= 0:
+            return int(p)
+        return None
+
+    if isinstance(expr, BinaryOp):
+        op = expr.op
+        if op == "**":
+            if not isinstance(expr.right, Constant):
+                return None
+            exp_val = expr.right.value
+            if not isinstance(exp_val, numbers.Number):
+                return None
+            exp_float = float(exp_val)
+            if not exp_float.is_integer() or exp_float < 0:
+                return None
+            left_deg = _compute_poly_degree(expr.left)
+            if left_deg is None:
+                return None
+            return left_deg * int(exp_float)
+        if op == "/":
+            if not isinstance(expr.right, Constant):
+                return None
+            return _compute_poly_degree(expr.left)
+        if op in ("+", "-"):
+            ld = _compute_poly_degree(expr.left)
+            if ld is None:
+                return None
+            rd = _compute_poly_degree(expr.right)
+            if rd is None:
+                return None
+            return max(ld, rd)
+        if op == "*":
+            ld = _compute_poly_degree(expr.left)
+            if ld is None:
+                return None
+            rd = _compute_poly_degree(expr.right)
+            if rd is None:
+                return None
+            return ld + rd
+
+    if isinstance(expr, UnaryOp):
+        if expr.op == "neg":
+            return _compute_poly_degree(expr.operand)
+        return None
+
+    if isinstance(expr, NarySum):
+        max_d = 0
+        for t in expr.terms:
+            d = _compute_poly_degree(t)
+            if d is None:
+                return None
+            max_d = max(max_d, d)
+        return max_d
+
+    return None
+
+
+def _is_at_most_quadratic(expr: Expression) -> bool:
+    """Check if an expression is at most quadratic (degree <= 2)."""
+    d = _compute_poly_degree(expr)
+    return d is not None and d <= 2
+
+
+def write_lp(problem: Problem, filename: str) -> None:
+    """Export a Problem to LP file format.
+
+    Args:
+        problem: The optimization problem to export.
+        filename: Path to the output .lp file.
+
+    Raises:
+        InvalidOperationError: If the problem contains nonlinear (non-quadratic)
+            expressions that cannot be represented in LP format.
+        NoObjectiveError: If no objective has been set.
+    """
+    content = _format_lp(problem)
+    with open(filename, "w") as f:
+        f.write(content)
+
+
+def format_lp(problem: Problem) -> str:
+    """Format a Problem as an LP format string (without writing to file).
+
+    Args:
+        problem: The optimization problem to format.
+
+    Returns:
+        The LP format string.
+
+    Raises:
+        InvalidOperationError: If the problem contains nonlinear expressions.
+    """
+    return _format_lp(problem)
+
+
+def _format_lp(problem: Problem) -> str:
+    """Build the LP format string for a problem."""
+    from optyx.core.errors import NoObjectiveError
+
+    if problem.objective is None:
+        raise NoObjectiveError(
+            suggestion="Set an objective with minimize() or maximize() before exporting."
+        )
+
+    variables = problem.variables
+    if not variables:
+        raise InvalidOperationError(
+            operation="LP export",
+            operand_types="Problem",
+            reason="Problem has no variables.",
+        )
+
+    # Validate: objective and constraints must be at most quadratic
+    obj = problem.objective
+    if not _is_at_most_quadratic(obj):
+        raise InvalidOperationError(
+            operation="LP export",
+            operand_types=type(obj).__name__,
+            reason="LP format only supports linear and quadratic objectives.",
+            suggestion="Nonlinear objectives cannot be exported to LP format.",
+        )
+
+    for i, c in enumerate(problem.constraints):
+        if not is_linear(c.expr):
+            name = c.name or f"c{i}"
+            raise InvalidOperationError(
+                operation="LP export",
+                operand_types=type(c.expr).__name__,
+                reason=f"Constraint '{name}' is not linear. LP format only supports linear constraints.",
+                suggestion="Only linear constraints can be exported to LP format.",
+            )
+
+    lines: list[str] = []
+
+    # Comment header
+    name = problem.name or "optyx_model"
+    lines.append(f"\\ Model {name}")
+    lines.append("")
+
+    # Objective section
+    _write_objective(lines, problem, variables)
+
+    # Constraints section
+    _write_constraints(lines, problem, variables)
+
+    # Bounds section
+    _write_bounds(lines, variables)
+
+    # Integer / Binary variable sections
+    _write_variable_types(lines, variables)
+
+    lines.append("End")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _write_objective(
+    lines: list[str], problem: Problem, variables: list[Variable]
+) -> None:
+    """Write the objective function section."""
+    obj = problem.objective
+    assert obj is not None
+
+    sense = "Minimize" if problem.sense == "minimize" else "Maximize"
+    lines.append(sense)
+
+    # Extract linear part
+    linear_terms = _extract_linear_terms(obj, variables)
+    constant = extract_constant_term(obj) if is_linear(obj) else _extract_constant_from_quadratic(obj)
+
+    # Extract quadratic part (if any)
+    quad_terms: list[tuple[str, str, float]] = []
+    if not is_linear(obj):
+        quad_terms = _extract_quadratic_terms(obj, variables)
+
+    # Format the objective line
+    obj_str = _format_expression(linear_terms, quad_terms, constant)
+    lines.append(f"  obj: {obj_str}")
+    lines.append("")
+
+
+def _write_constraints(
+    lines: list[str], problem: Problem, variables: list[Variable]
+) -> None:
+    """Write the constraints section."""
+    all_constraints = problem.constraints
+    matrix_constraints = problem._matrix_constraints
+
+    if not all_constraints and not matrix_constraints:
+        return
+
+    lines.append("Subject To")
+
+    # Expression-based constraints
+    for i, c in enumerate(all_constraints):
+        name = c.name or f"c{i}"
+        linear_terms = _extract_linear_terms(c.expr, variables)
+        constant = extract_constant_term(c.expr)
+
+        # Constraint is: expr sense 0, so expr - constant sense -constant
+        # We write: linear_part sense -constant
+        lhs_str = _format_expression(linear_terms, [], 0.0)
+        rhs = -constant
+
+        if not lhs_str or lhs_str.strip() == "0":
+            lhs_str = "0"
+
+        sense_str = c.sense
+        lines.append(f"  {name}: {lhs_str} {sense_str} {_format_number(rhs)}")
+
+    # Matrix constraints: A @ x sense b
+    constraint_offset = len(all_constraints)
+    for mc in matrix_constraints:
+        A = mc.A
+        b = mc.b
+        sense_str = mc.sense
+        mc_vars = mc.variables
+
+        # Build variable name list for this matrix constraint
+        var_names = [v.name for v in mc_vars]
+
+        m = A.shape[0]
+        for row_idx in range(m):
+            name = f"c{constraint_offset + row_idx}"
+
+            # Extract row coefficients
+            from scipy import sparse as sp
+            if sp.issparse(A):
+                row = A.getrow(row_idx)
+                indices = row.indices
+                data = row.data
+                terms: list[tuple[str, float]] = [
+                    (var_names[j], float(data[k]))
+                    for k, j in enumerate(indices)
+                    if abs(data[k]) > 1e-15
+                ]
+            else:
+                row_data = A[row_idx]
+                terms = [
+                    (var_names[j], float(row_data[j]))
+                    for j in range(len(var_names))
+                    if abs(row_data[j]) > 1e-15
+                ]
+
+            lhs_str = _format_linear_terms(terms)
+            if not lhs_str:
+                lhs_str = "0"
+
+            rhs = float(b[row_idx])
+            lines.append(f"  {name}: {lhs_str} {sense_str} {_format_number(rhs)}")
+
+        constraint_offset += m
+
+    lines.append("")
+
+
+def _write_bounds(lines: list[str], variables: list[Variable]) -> None:
+    """Write the bounds section."""
+    lines.append("Bounds")
+
+    for v in variables:
+        lb = v.lb
+        ub = v.ub
+
+        # Skip binary variables (handled in Binaries section with implicit 0/1 bounds)
+        if v.domain == "binary":
+            lines.append(f"  0 <= {v.name} <= 1")
+            continue
+
+        if lb is None and ub is None:
+            # Free variable
+            lines.append(f"  {v.name} free")
+        elif lb is not None and ub is not None:
+            lines.append(f"  {_format_number(lb)} <= {v.name} <= {_format_number(ub)}")
+        elif lb is not None:
+            lines.append(f"  {_format_number(lb)} <= {v.name}")
+        else:
+            # ub only
+            lines.append(f"  -inf <= {v.name} <= {_format_number(ub)}")
+
+    lines.append("")
+
+
+def _write_variable_types(lines: list[str], variables: list[Variable]) -> None:
+    """Write Generals and Binaries sections."""
+    generals = [v.name for v in variables if v.domain == "integer"]
+    binaries = [v.name for v in variables if v.domain == "binary"]
+
+    if generals:
+        lines.append("Generals")
+        for name in generals:
+            lines.append(f"  {name}")
+        lines.append("")
+
+    if binaries:
+        lines.append("Binaries")
+        for name in binaries:
+            lines.append(f"  {name}")
+        lines.append("")
+
+
+# =============================================================================
+# Expression formatting helpers
+# =============================================================================
+
+
+def _extract_linear_terms(
+    expr: Expression, variables: list[Variable]
+) -> list[tuple[str, float]]:
+    """Extract linear coefficient for each variable from a (possibly quadratic) expression.
+
+    For quadratic expressions, this extracts only the linear part.
+    """
+    terms: list[tuple[str, float]] = []
+
+    if is_linear(expr):
+        for v in variables:
+            coeff = extract_linear_coefficient(expr, v)
+            if abs(coeff) > 1e-15:
+                terms.append((v.name, coeff))
+    else:
+        # Quadratic expression — extract linear terms by walking the tree
+        linear_coeffs = _extract_linear_from_quadratic(expr, variables)
+        for v, coeff in zip(variables, linear_coeffs):
+            if abs(coeff) > 1e-15:
+                terms.append((v.name, coeff))
+
+    return terms
+
+
+def _extract_quadratic_terms(
+    expr: Expression, variables: list[Variable]
+) -> list[tuple[str, str, float]]:
+    """Extract quadratic terms as (var_i, var_j, coeff) triples.
+
+    Returns terms where i <= j (upper triangle), with coefficients
+    adjusted for LP format conventions:
+    - Diagonal: x_i^2 has coefficient as-is
+    - Off-diagonal: x_i * x_j has coefficient (summed for both orderings)
+    """
+    from optyx.core.matrices import QuadraticForm
+    from optyx.core.vectors import DotProduct, VectorVariable, VectorPowerSum
+
+    n = len(variables)
+    var_index = {v.name: i for i, v in enumerate(variables)}
+    Q = np.zeros((n, n), dtype=np.float64)
+
+    _collect_quadratic_coefficients(expr, var_index, Q, 1.0)
+
+    # Convert Q matrix to list of (var_i, var_j, coeff) with i <= j
+    terms: list[tuple[str, str, float]] = []
+    for i in range(n):
+        for j in range(i, n):
+            if i == j:
+                coeff = Q[i, j]
+            else:
+                # Combine symmetric entries
+                coeff = Q[i, j] + Q[j, i]
+            if abs(coeff) > 1e-15:
+                terms.append((variables[i].name, variables[j].name, coeff))
+
+    return terms
+
+
+def _collect_quadratic_coefficients(
+    expr: Expression,
+    var_index: dict[str, int],
+    Q: np.ndarray,
+    multiplier: float,
+) -> None:
+    """Recursively collect quadratic coefficients into matrix Q.
+
+    Walks the expression tree accounting for + - * and known quadratic patterns.
+    """
+    from optyx.core.matrices import QuadraticForm
+    from optyx.core.vectors import (
+        DotProduct,
+        VectorVariable,
+        VectorPowerSum,
+        VectorExpression,
+    )
+
+    # Leaf nodes — no quadratic contribution
+    if isinstance(expr, (Constant, Variable)):
+        return
+
+    # QuadraticForm: x' Q x
+    if isinstance(expr, QuadraticForm):
+        if isinstance(expr.vector, VectorVariable):
+            qvars = expr.vector._variables
+            matrix = expr.matrix
+            for i, vi in enumerate(qvars):
+                idx_i = var_index.get(vi.name)
+                if idx_i is None:
+                    continue
+                for j, vj in enumerate(qvars):
+                    idx_j = var_index.get(vj.name)
+                    if idx_j is None:
+                        continue
+                    Q[idx_i, idx_j] += multiplier * matrix[i, j]
+        return
+
+    # DotProduct: x.dot(x) = sum(x_i^2) when left is right
+    if isinstance(expr, DotProduct):
+        if (isinstance(expr.left, VectorVariable) and isinstance(expr.right, VectorVariable)
+                and expr.left is expr.right):
+            for v in expr.left._variables:
+                idx = var_index.get(v.name)
+                if idx is not None:
+                    Q[idx, idx] += multiplier
+        return
+
+    # VectorPowerSum: sum(x ** 2)
+    if isinstance(expr, VectorPowerSum):
+        if expr.power == 2.0 and isinstance(expr.vector, VectorVariable):
+            for v in expr.vector._variables:
+                idx = var_index.get(v.name)
+                if idx is not None:
+                    Q[idx, idx] += multiplier
+        return
+
+    # BinaryOp
+    if isinstance(expr, BinaryOp):
+        if expr.op == "+":
+            _collect_quadratic_coefficients(expr.left, var_index, Q, multiplier)
+            _collect_quadratic_coefficients(expr.right, var_index, Q, multiplier)
+            return
+        if expr.op == "-":
+            _collect_quadratic_coefficients(expr.left, var_index, Q, multiplier)
+            _collect_quadratic_coefficients(expr.right, var_index, Q, -multiplier)
+            return
+        if expr.op == "*":
+            # scalar * quadratic_expr or quadratic_expr * scalar
+            if isinstance(expr.left, Constant):
+                _collect_quadratic_coefficients(
+                    expr.right, var_index, Q, multiplier * float(expr.left.value)
+                )
+                return
+            if isinstance(expr.right, Constant):
+                _collect_quadratic_coefficients(
+                    expr.left, var_index, Q, multiplier * float(expr.right.value)
+                )
+                return
+            # var * var — quadratic term
+            left_vars = expr.left.get_variables()
+            right_vars = expr.right.get_variables()
+            if len(left_vars) == 1 and len(right_vars) == 1:
+                lv = next(iter(left_vars))
+                rv = next(iter(right_vars))
+                li = var_index.get(lv.name)
+                ri = var_index.get(rv.name)
+                if li is not None and ri is not None:
+                    # Handle coefficient*var * coefficient*var
+                    lc = _get_scalar_linear_coeff(expr.left, lv)
+                    rc = _get_scalar_linear_coeff(expr.right, rv)
+                    Q[li, ri] += multiplier * lc * rc
+            return
+        if expr.op == "**":
+            # var ** 2
+            if isinstance(expr.right, Constant) and float(expr.right.value) == 2.0:
+                left_vars = expr.left.get_variables()
+                if len(left_vars) == 1:
+                    lv = next(iter(left_vars))
+                    li = var_index.get(lv.name)
+                    if li is not None:
+                        lc = _get_scalar_linear_coeff(expr.left, lv)
+                        Q[li, li] += multiplier * lc * lc
+            return
+        if expr.op == "/":
+            if isinstance(expr.right, Constant):
+                _collect_quadratic_coefficients(
+                    expr.left, var_index, Q, multiplier / float(expr.right.value)
+                )
+            return
+
+    # UnaryOp
+    if isinstance(expr, UnaryOp):
+        if expr.op == "neg":
+            _collect_quadratic_coefficients(expr.operand, var_index, Q, -multiplier)
+        return
+
+    # NarySum
+    if isinstance(expr, NarySum):
+        for term in expr.terms:
+            _collect_quadratic_coefficients(term, var_index, Q, multiplier)
+        return
+
+
+def _get_scalar_linear_coeff(expr: Expression, var: Variable) -> float:
+    """Get the linear coefficient of a single-variable linear expression.
+
+    For expressions like `3*x`, returns 3.0. For just `x`, returns 1.0.
+    """
+    if isinstance(expr, Variable):
+        return 1.0
+    if isinstance(expr, BinaryOp):
+        if expr.op == "*":
+            if isinstance(expr.left, Constant):
+                return float(expr.left.value) * _get_scalar_linear_coeff(expr.right, var)
+            if isinstance(expr.right, Constant):
+                return _get_scalar_linear_coeff(expr.left, var) * float(expr.right.value)
+        if expr.op == "/":
+            if isinstance(expr.right, Constant):
+                return _get_scalar_linear_coeff(expr.left, var) / float(expr.right.value)
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return -_get_scalar_linear_coeff(expr.operand, var)
+    return 1.0
+
+
+def _extract_linear_from_quadratic(
+    expr: Expression, variables: list[Variable]
+) -> list[float]:
+    """Extract only the linear coefficients from a quadratic expression.
+
+    Walks the tree, ignoring quadratic terms, and collects linear contributions.
+    """
+    n = len(variables)
+    var_index = {v.name: i for i, v in enumerate(variables)}
+    result = [0.0] * n
+    _collect_linear_from_quadratic(expr, var_index, result, 1.0)
+    return result
+
+
+def _collect_linear_from_quadratic(
+    expr: Expression,
+    var_index: dict[str, int],
+    result: list[float],
+    multiplier: float,
+) -> None:
+    """Recursively collect linear coefficients, skipping quadratic terms."""
+    from optyx.core.matrices import QuadraticForm
+    from optyx.core.vectors import (
+        DotProduct,
+        VectorVariable,
+        VectorSum,
+        LinearCombination,
+        VectorPowerSum,
+    )
+
+    # Constant — no linear contribution
+    if isinstance(expr, Constant):
+        return
+
+    # Variable — linear contribution
+    if isinstance(expr, Variable):
+        idx = var_index.get(expr.name)
+        if idx is not None:
+            result[idx] += multiplier
+        return
+
+    # VectorSum: sum(x) — each variable coefficient is 1
+    if isinstance(expr, VectorSum):
+        if isinstance(expr.vector, VectorVariable):
+            for v in expr.vector._variables:
+                idx = var_index.get(v.name)
+                if idx is not None:
+                    result[idx] += multiplier
+        return
+
+    # LinearCombination: c @ x
+    if isinstance(expr, LinearCombination):
+        if isinstance(expr.vector, VectorVariable):
+            for i, v in enumerate(expr.vector._variables):
+                idx = var_index.get(v.name)
+                if idx is not None:
+                    result[idx] += multiplier * float(expr.coefficients[i])
+        return
+
+    # Purely quadratic — no linear contribution
+    if isinstance(expr, (QuadraticForm, DotProduct, VectorPowerSum)):
+        return
+
+    # BinaryOp
+    if isinstance(expr, BinaryOp):
+        if expr.op == "+":
+            _collect_linear_from_quadratic(expr.left, var_index, result, multiplier)
+            _collect_linear_from_quadratic(expr.right, var_index, result, multiplier)
+            return
+        if expr.op == "-":
+            _collect_linear_from_quadratic(expr.left, var_index, result, multiplier)
+            _collect_linear_from_quadratic(expr.right, var_index, result, -multiplier)
+            return
+        if expr.op == "*":
+            if isinstance(expr.left, Constant):
+                _collect_linear_from_quadratic(
+                    expr.right, var_index, result, multiplier * float(expr.left.value)
+                )
+                return
+            if isinstance(expr.right, Constant):
+                _collect_linear_from_quadratic(
+                    expr.left, var_index, result, multiplier * float(expr.right.value)
+                )
+                return
+            # var * var — quadratic, no linear contribution
+            return
+        if expr.op == "/":
+            if isinstance(expr.right, Constant):
+                _collect_linear_from_quadratic(
+                    expr.left, var_index, result, multiplier / float(expr.right.value)
+                )
+            return
+        if expr.op == "**":
+            # x**2 is quadratic, skip; x**1 is handled as Variable
+            if isinstance(expr.right, Constant) and float(expr.right.value) == 1.0:
+                _collect_linear_from_quadratic(expr.left, var_index, result, multiplier)
+            return
+
+    # UnaryOp
+    if isinstance(expr, UnaryOp):
+        if expr.op == "neg":
+            _collect_linear_from_quadratic(expr.operand, var_index, result, -multiplier)
+        return
+
+    # NarySum
+    if isinstance(expr, NarySum):
+        for term in expr.terms:
+            _collect_linear_from_quadratic(term, var_index, result, multiplier)
+        return
+
+
+def _extract_constant_from_quadratic(expr: Expression) -> float:
+    """Extract constant term from a quadratic expression."""
+    if isinstance(expr, Constant):
+        return float(expr.value)
+    if isinstance(expr, Variable):
+        return 0.0
+    if isinstance(expr, BinaryOp):
+        if expr.op == "+":
+            return _extract_constant_from_quadratic(expr.left) + _extract_constant_from_quadratic(expr.right)
+        if expr.op == "-":
+            return _extract_constant_from_quadratic(expr.left) - _extract_constant_from_quadratic(expr.right)
+        if expr.op == "*":
+            if isinstance(expr.left, Constant):
+                return float(expr.left.value) * _extract_constant_from_quadratic(expr.right)
+            if isinstance(expr.right, Constant):
+                return _extract_constant_from_quadratic(expr.left) * float(expr.right.value)
+            return 0.0
+        if expr.op == "/":
+            if isinstance(expr.right, Constant):
+                return _extract_constant_from_quadratic(expr.left) / float(expr.right.value)
+            return 0.0
+        if expr.op == "**":
+            if isinstance(expr.right, Constant) and float(expr.right.value) == 0.0:
+                return 1.0
+            return 0.0
+    if isinstance(expr, UnaryOp):
+        if expr.op == "neg":
+            return -_extract_constant_from_quadratic(expr.operand)
+        return 0.0
+    if isinstance(expr, NarySum):
+        return sum(_extract_constant_from_quadratic(t) for t in expr.terms)
+    return 0.0
+
+
+def _format_expression(
+    linear_terms: list[tuple[str, float]],
+    quad_terms: list[tuple[str, str, float]],
+    constant: float,
+) -> str:
+    """Format an expression as LP format string.
+
+    LP format for quadratic objectives uses [ ... ] / 2 notation.
+    """
+    parts: list[str] = []
+
+    # Linear terms
+    linear_str = _format_linear_terms(linear_terms)
+    if linear_str:
+        parts.append(linear_str)
+
+    # Quadratic terms ([ ... ] / 2 notation)
+    if quad_terms:
+        quad_str = _format_quadratic_section(quad_terms)
+        parts.append(quad_str)
+
+    # Constant term
+    if abs(constant) > 1e-15:
+        const_str = _format_number(constant)
+        if parts:
+            if constant > 0:
+                parts.append(f"+ {const_str}")
+            else:
+                parts.append(f"- {_format_number(-constant)}")
+        else:
+            parts.append(const_str)
+
+    if not parts:
+        return "0"
+
+    return " ".join(parts)
+
+
+def _format_linear_terms(terms: list[tuple[str, float]]) -> str:
+    """Format linear terms like '2 x0 + 3 x1 - x2'."""
+    if not terms:
+        return ""
+
+    parts: list[str] = []
+    for i, (name, coeff) in enumerate(terms):
+        if i == 0:
+            # First term: no leading space/sign unless negative
+            if coeff == 1.0:
+                parts.append(name)
+            elif coeff == -1.0:
+                parts.append(f"- {name}")
+            elif coeff < 0:
+                parts.append(f"- {_format_number(-coeff)} {name}")
+            else:
+                parts.append(f"{_format_number(coeff)} {name}")
+        else:
+            # Subsequent terms: always have + or -
+            if coeff == 1.0:
+                parts.append(f"+ {name}")
+            elif coeff == -1.0:
+                parts.append(f"- {name}")
+            elif coeff < 0:
+                parts.append(f"- {_format_number(-coeff)} {name}")
+            else:
+                parts.append(f"+ {_format_number(coeff)} {name}")
+
+    return " ".join(parts)
+
+
+def _format_quadratic_section(
+    quad_terms: list[tuple[str, str, float]],
+) -> str:
+    """Format quadratic terms in LP format: [ 2 x0 ^2 + 4 x0 * x1 ] / 2.
+
+    LP format convention: the quadratic section is [ Q_terms ] / 2,
+    where Q_terms use doubled coefficients (so the actual contribution is halved).
+    """
+    parts: list[str] = []
+    for i, (vi, vj, coeff) in enumerate(quad_terms):
+        # Double the coefficient for LP [ ... ] / 2 convention
+        doubled = 2.0 * coeff
+
+        if vi == vj:
+            term = f"{vi} ^2"
+        else:
+            term = f"{vi} * {vj}"
+
+        if i == 0:
+            if doubled == 1.0:
+                parts.append(term)
+            elif doubled == -1.0:
+                parts.append(f"- {term}")
+            elif doubled < 0:
+                parts.append(f"- {_format_number(-doubled)} {term}")
+            else:
+                parts.append(f"{_format_number(doubled)} {term}")
+        else:
+            if doubled == 1.0:
+                parts.append(f"+ {term}")
+            elif doubled == -1.0:
+                parts.append(f"- {term}")
+            elif doubled < 0:
+                parts.append(f"- {_format_number(-doubled)} {term}")
+            else:
+                parts.append(f"+ {_format_number(doubled)} {term}")
+
+    return "[ " + " ".join(parts) + " ] / 2"
+
+
+def _format_number(value: float) -> str:
+    """Format a number for LP output, removing unnecessary trailing zeros."""
+    if value == float("inf"):
+        return "inf"
+    if value == float("-inf"):
+        return "-inf"
+    if value == int(value):
+        return str(int(value))
+    # Format with reasonable precision, strip trailing zeros
+    formatted = f"{value:.10g}"
+    return formatted

--- a/src/optyx/problem.py
+++ b/src/optyx/problem.py
@@ -856,6 +856,50 @@ class Problem:
             f"n_constraints={self.n_constraints})"
         )
 
+    def write(self, filename: str) -> None:
+        """Export the problem to LP file format.
+
+        Writes the problem formulation to a human-readable .lp file,
+        compatible with solvers like CPLEX, Gurobi, GLPK, and HiGHS.
+
+        Supports linear and quadratic objectives, linear constraints,
+        variable bounds, and integer/binary variable types.
+
+        Args:
+            filename: Path to the output .lp file.
+
+        Raises:
+            InvalidOperationError: If the problem contains nonlinear
+                expressions that cannot be represented in LP format.
+            NoObjectiveError: If no objective has been set.
+
+        Example:
+            >>> x = Variable("x", lb=0)
+            >>> y = Variable("y", lb=0)
+            >>> prob = Problem("example")
+            >>> prob.minimize(2 * x + 3 * y)
+            >>> prob.subject_to(x + y >= 1)
+            >>> prob.write("example.lp")
+        """
+        from optyx.io import write_lp
+
+        write_lp(self, filename)
+
+    def to_lp(self) -> str:
+        """Return the LP format string representation of the problem.
+
+        Like write(), but returns the string instead of writing to a file.
+
+        Returns:
+            The LP format string.
+
+        Raises:
+            InvalidOperationError: If the problem contains nonlinear expressions.
+        """
+        from optyx.io import format_lp
+
+        return format_lp(self)
+
     def summary(self) -> str:
         """Return a human-readable summary of the optimization problem.
 

--- a/tests/test_lp_export.py
+++ b/tests/test_lp_export.py
@@ -1,0 +1,684 @@
+"""Tests for LP format export (Issue #106)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from optyx import (
+    BinaryVariable,
+    IntegerVariable,
+    Problem,
+    Variable,
+    VectorVariable,
+    VariableDict,
+    quadratic_form,
+    sin,
+    exp,
+)
+from optyx.io import write_lp, format_lp
+from optyx.analysis import extract_quadratic_coefficients
+from optyx.core.errors import InvalidOperationError, NoObjectiveError
+
+
+# =============================================================================
+# Test Problem.write() and Problem.to_lp()
+# =============================================================================
+
+
+class TestProblemWrite:
+    """Tests for Problem.write() file output."""
+
+    def test_write_creates_file(self, tmp_path):
+        x = Variable("x", lb=0)
+        prob = Problem("test")
+        prob.minimize(x)
+        filepath = str(tmp_path / "model.lp")
+        prob.write(filepath)
+        assert os.path.exists(filepath)
+
+    def test_write_content_matches_to_lp(self, tmp_path):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem("test")
+        prob.minimize(x + y)
+        prob.subject_to(x + y >= 1)
+        filepath = str(tmp_path / "model.lp")
+        prob.write(filepath)
+        with open(filepath) as f:
+            content = f.read()
+        assert content == prob.to_lp()
+
+    def test_to_lp_returns_string(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        result = prob.to_lp()
+        assert isinstance(result, str)
+        assert "Minimize" in result
+        assert "End" in result
+
+
+# =============================================================================
+# Test LP Format Structure
+# =============================================================================
+
+
+class TestLPFormatStructure:
+    """Tests for the overall LP format structure."""
+
+    def test_model_name_in_comment(self):
+        prob = Problem("my_model")
+        prob.minimize(Variable("x", lb=0))
+        lp = prob.to_lp()
+        assert lp.startswith("\\ Model my_model")
+
+    def test_default_model_name(self):
+        prob = Problem()
+        prob.minimize(Variable("x", lb=0))
+        lp = prob.to_lp()
+        assert "\\ Model optyx_model" in lp
+
+    def test_sections_order(self):
+        x = Variable("x", lb=0)
+        y = IntegerVariable("y", lb=0, ub=5)
+        prob = Problem()
+        prob.minimize(x + y)
+        prob.subject_to(x + y >= 1)
+        lp = prob.to_lp()
+        lines = lp.split("\n")
+
+        # Find section positions
+        minimize_idx = next(i for i, l in enumerate(lines) if l.strip() == "Minimize")
+        subject_idx = next(i for i, l in enumerate(lines) if l.strip() == "Subject To")
+        bounds_idx = next(i for i, l in enumerate(lines) if l.strip() == "Bounds")
+        generals_idx = next(i for i, l in enumerate(lines) if l.strip() == "Generals")
+        end_idx = next(i for i, l in enumerate(lines) if l.strip() == "End")
+
+        assert minimize_idx < subject_idx < bounds_idx < generals_idx < end_idx
+
+    def test_end_keyword(self):
+        prob = Problem()
+        prob.minimize(Variable("x", lb=0))
+        lp = prob.to_lp()
+        assert lp.strip().endswith("End")
+
+
+# =============================================================================
+# Test Linear Objectives
+# =============================================================================
+
+
+class TestLinearObjective:
+    """Tests for linear objective formatting."""
+
+    def test_minimize_single_variable(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        lp = prob.to_lp()
+        assert "Minimize" in lp
+        assert "obj: x" in lp
+
+    def test_maximize(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.maximize(x)
+        lp = prob.to_lp()
+        assert "Maximize" in lp
+
+    def test_coefficient_formatting(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(2 * x + 3 * y)
+        lp = prob.to_lp()
+        assert "2 x" in lp
+        assert "3 y" in lp
+
+    def test_negative_coefficient(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x - 2 * y)
+        lp = prob.to_lp()
+        assert "- 2 y" in lp
+
+    def test_unit_coefficient_omitted(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x + y)
+        lp = prob.to_lp()
+        # "1 x" should not appear — just "x"
+        assert "1 x" not in lp
+        assert "obj: x + y" in lp
+
+    def test_negative_unit_coefficient(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x - y)
+        lp = prob.to_lp()
+        assert "obj: x - y" in lp
+
+    def test_vector_sum_objective(self):
+        x = VectorVariable("x", 3, lb=0)
+        prob = Problem()
+        prob.minimize(x.sum())
+        lp = prob.to_lp()
+        assert "x[0]" in lp
+        assert "x[1]" in lp
+        assert "x[2]" in lp
+
+    def test_linear_combination_objective(self):
+        x = VectorVariable("x", 3, lb=0)
+        c = np.array([1.0, 2.0, 3.0])
+        prob = Problem()
+        prob.minimize(c @ x)
+        lp = prob.to_lp()
+        assert "x[0]" in lp
+        assert "2 x[1]" in lp
+        assert "3 x[2]" in lp
+
+
+# =============================================================================
+# Test Quadratic Objectives
+# =============================================================================
+
+
+class TestQuadraticObjective:
+    """Tests for quadratic objective formatting."""
+
+    def test_simple_quadratic(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x**2)
+        lp = prob.to_lp()
+        assert "[" in lp
+        assert "] / 2" in lp
+        assert "x ^2" in lp
+
+    def test_cross_term(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x * y)
+        lp = prob.to_lp()
+        assert "x * y" in lp
+
+    def test_mixed_linear_quadratic(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x + y + x**2 + x * y + y**2)
+        lp = prob.to_lp()
+        # Should have both linear and quadratic parts
+        assert "x + y" in lp or ("x" in lp and "y" in lp)
+        assert "[" in lp
+        assert "] / 2" in lp
+
+    def test_dot_product_self(self):
+        x = VectorVariable("x", 3, lb=0)
+        prob = Problem()
+        prob.minimize(x.dot(x))
+        lp = prob.to_lp()
+        assert "x[0] ^2" in lp
+        assert "x[1] ^2" in lp
+        assert "x[2] ^2" in lp
+
+    def test_quadratic_form(self):
+        x = VectorVariable("x", 2, lb=0)
+        Q = np.array([[2.0, 1.0], [1.0, 3.0]])
+        prob = Problem()
+        prob.minimize(quadratic_form(x, Q))
+        lp = prob.to_lp()
+        assert "[" in lp
+        assert "x[0] ^2" in lp
+        assert "x[0] * x[1]" in lp
+        assert "x[1] ^2" in lp
+
+    def test_quadratic_form_coefficients(self):
+        """Verify quadratic coefficients are correct in LP format."""
+        x = VectorVariable("x", 2, lb=0)
+        Q = np.array([[2.0, 0.5], [0.5, 3.0]])
+        prob = Problem()
+        prob.minimize(quadratic_form(x, Q))
+        lp = prob.to_lp()
+        # LP format: [ 2*coeff terms ] / 2
+        # x[0]^2 coeff = 2.0, doubled = 4.0
+        assert "4 x[0] ^2" in lp
+        # x[0]*x[1] coeff = 0.5+0.5 = 1.0, doubled = 2.0
+        assert "2 x[0] * x[1]" in lp
+        # x[1]^2 coeff = 3.0, doubled = 6.0
+        assert "6 x[1] ^2" in lp
+
+
+# =============================================================================
+# Test Constraints
+# =============================================================================
+
+
+class TestConstraints:
+    """Tests for constraint formatting."""
+
+    def test_le_constraint(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        prob.subject_to(x <= 10)
+        lp = prob.to_lp()
+        assert "<=" in lp
+        assert "10" in lp
+
+    def test_ge_constraint(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        prob.subject_to(x >= 1)
+        lp = prob.to_lp()
+        assert ">=" in lp
+        assert "1" in lp
+
+    def test_eq_constraint(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x + y)
+        prob.subject_to((x + y).eq(1))
+        lp = prob.to_lp()
+        assert "==" in lp
+
+    def test_multiple_constraints(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x + y)
+        prob.subject_to(x + y >= 1)
+        prob.subject_to(x - y <= 5)
+        prob.subject_to((x + y).eq(3))
+        lp = prob.to_lp()
+        assert "c0:" in lp
+        assert "c1:" in lp
+        assert "c2:" in lp
+
+    def test_named_constraint(self):
+        from optyx.constraints import Constraint
+
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x + y)
+        c = Constraint(expr=x + y - 1, sense=">=", name="demand")
+        prob.subject_to(c)
+        lp = prob.to_lp()
+        assert "demand:" in lp
+
+    def test_no_constraints(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        lp = prob.to_lp()
+        assert "Subject To" not in lp
+
+    def test_constraint_with_constant(self):
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        prob.subject_to(2 * x + 3 * y >= 6)
+        lp = prob.to_lp()
+        assert "2 x" in lp
+        assert "3 y" in lp
+        assert ">=" in lp
+        assert "6" in lp
+
+
+# =============================================================================
+# Test Matrix Constraints
+# =============================================================================
+
+
+class TestMatrixConstraints:
+    """Tests for matrix constraint formatting."""
+
+    def test_dense_matrix_constraints(self):
+        x = VectorVariable("x", 3, lb=0)
+        A = np.array([[1, 2, 3], [4, 5, 6]])
+        b = np.array([10, 20])
+        prob = Problem()
+        prob.minimize(x.sum())
+        prob.subject_to_matrix(A, x, "<=", b)
+        lp = prob.to_lp()
+        assert "<=" in lp
+        assert "10" in lp
+        assert "20" in lp
+
+    def test_sparse_matrix_constraints(self):
+        from scipy import sparse as sp
+
+        x = VectorVariable("x", 5, lb=0)
+        A = sp.csr_matrix(np.array([[1, 0, 0, 2, 0], [0, 3, 0, 0, 4]]))
+        b = np.array([5, 6])
+        prob = Problem()
+        prob.minimize(x.sum())
+        prob.subject_to_matrix(A, x, ">=", b)
+        lp = prob.to_lp()
+        assert ">=" in lp
+        # Zero coefficients should be omitted
+        lines = lp.split("\n")
+        constraint_lines = [l for l in lines if l.strip().startswith("c")]
+        # First constraint should have x[0] and x[3]
+        assert "x[0]" in constraint_lines[0]
+        assert "x[3]" in constraint_lines[0]
+
+    def test_mixed_expression_and_matrix_constraints(self):
+        x = VectorVariable("x", 3, lb=0)
+        A = np.array([[1, 1, 1]])
+        b = np.array([10])
+        prob = Problem()
+        prob.minimize(x.sum())
+        prob.subject_to(x[0] >= 1)
+        prob.subject_to_matrix(A, x, "<=", b)
+        lp = prob.to_lp()
+        assert "c0:" in lp
+        assert "c1:" in lp
+
+
+# =============================================================================
+# Test Bounds
+# =============================================================================
+
+
+class TestBounds:
+    """Tests for variable bounds formatting."""
+
+    def test_lower_bound_only(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        lp = prob.to_lp()
+        assert "0 <= x" in lp
+
+    def test_upper_bound_only(self):
+        x = Variable("x", ub=10)
+        prob = Problem()
+        prob.minimize(x)
+        lp = prob.to_lp()
+        assert "-inf <= x <= 10" in lp
+
+    def test_both_bounds(self):
+        x = Variable("x", lb=0, ub=10)
+        prob = Problem()
+        prob.minimize(x)
+        lp = prob.to_lp()
+        assert "0 <= x <= 10" in lp
+
+    def test_free_variable(self):
+        x = Variable("x")
+        prob = Problem()
+        prob.minimize(x)
+        lp = prob.to_lp()
+        assert "x free" in lp
+
+    def test_binary_bounds(self):
+        b = BinaryVariable("b")
+        prob = Problem()
+        prob.minimize(b)
+        lp = prob.to_lp()
+        assert "0 <= b <= 1" in lp
+
+
+# =============================================================================
+# Test Variable Types (Generals / Binaries)
+# =============================================================================
+
+
+class TestVariableTypes:
+    """Tests for integer and binary variable type sections."""
+
+    def test_integer_variable(self):
+        x = IntegerVariable("x", lb=0, ub=10)
+        prob = Problem()
+        prob.minimize(x)
+        lp = prob.to_lp()
+        assert "Generals" in lp
+        assert "  x" in lp
+
+    def test_binary_variable(self):
+        b = BinaryVariable("b")
+        prob = Problem()
+        prob.minimize(b)
+        lp = prob.to_lp()
+        assert "Binaries" in lp
+        assert "  b" in lp
+
+    def test_mixed_variable_types(self):
+        x = Variable("x", lb=0)
+        y = IntegerVariable("y", lb=0, ub=5)
+        z = BinaryVariable("z")
+        prob = Problem()
+        prob.minimize(x + y + z)
+        lp = prob.to_lp()
+        assert "Generals" in lp
+        assert "Binaries" in lp
+        # x should not appear in Generals or Binaries
+        generals_idx = lp.index("Generals")
+        binaries_idx = lp.index("Binaries")
+        generals_section = lp[generals_idx:binaries_idx]
+        assert "  y" in generals_section
+        binaries_section = lp[binaries_idx:]
+        assert "  z" in binaries_section
+
+    def test_no_generals_or_binaries_for_continuous(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        lp = prob.to_lp()
+        assert "Generals" not in lp
+        assert "Binaries" not in lp
+
+    def test_vector_integer_variables(self):
+        x = VectorVariable("x", 3, lb=0, ub=10, domain="integer")
+        prob = Problem()
+        prob.minimize(x.sum())
+        lp = prob.to_lp()
+        assert "Generals" in lp
+        assert "x[0]" in lp
+        assert "x[1]" in lp
+        assert "x[2]" in lp
+
+    def test_vector_binary_variables(self):
+        b = VectorVariable("b", 4, domain="binary")
+        prob = Problem()
+        prob.minimize(b.sum())
+        lp = prob.to_lp()
+        assert "Binaries" in lp
+
+
+# =============================================================================
+# Test Error Cases
+# =============================================================================
+
+
+class TestErrors:
+    """Tests for error handling."""
+
+    def test_no_objective_raises(self):
+        prob = Problem()
+        prob.subject_to(Variable("x", lb=0) >= 0)
+        with pytest.raises(NoObjectiveError):
+            prob.to_lp()
+
+    def test_nonlinear_objective_raises(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(sin(x))
+        with pytest.raises(InvalidOperationError, match="LP format only supports"):
+            prob.to_lp()
+
+    def test_nonlinear_constraint_raises(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(x)
+        prob.subject_to(sin(x) <= 1)
+        with pytest.raises(InvalidOperationError, match="not linear"):
+            prob.to_lp()
+
+    def test_exp_objective_raises(self):
+        x = Variable("x", lb=0)
+        prob = Problem()
+        prob.minimize(exp(x))
+        with pytest.raises(InvalidOperationError):
+            prob.to_lp()
+
+
+# =============================================================================
+# Test extract_quadratic_coefficients utility
+# =============================================================================
+
+
+class TestExtractQuadraticCoefficients:
+    """Tests for the extract_quadratic_coefficients analysis utility."""
+
+    def test_simple_square(self):
+        x = Variable("x")
+        Q = extract_quadratic_coefficients(x**2, [x])
+        assert Q.shape == (1, 1)
+        assert Q[0, 0] == pytest.approx(1.0)
+
+    def test_cross_term(self):
+        x = Variable("x")
+        y = Variable("y")
+        Q = extract_quadratic_coefficients(x * y, [x, y])
+        assert Q.shape == (2, 2)
+        # Symmetric: Q[0,1] = Q[1,0] = 0.5
+        assert Q[0, 1] == pytest.approx(0.5)
+        assert Q[1, 0] == pytest.approx(0.5)
+
+    def test_quadratic_form_extraction(self):
+        x = VectorVariable("x", 2)
+        Q_in = np.array([[2.0, 1.0], [1.0, 3.0]])
+        expr = quadratic_form(x, Q_in)
+        Q_out = extract_quadratic_coefficients(expr, list(x._variables))
+        np.testing.assert_array_almost_equal(Q_out, Q_in)
+
+    def test_dot_product_self(self):
+        x = VectorVariable("x", 3)
+        expr = x.dot(x)
+        Q = extract_quadratic_coefficients(expr, list(x._variables))
+        np.testing.assert_array_almost_equal(Q, np.eye(3))
+
+    def test_mixed_linear_quadratic_extracts_only_quadratic(self):
+        x = Variable("x")
+        y = Variable("y")
+        expr = x**2 + 3 * x + 2 * y
+        Q = extract_quadratic_coefficients(expr, [x, y])
+        assert Q[0, 0] == pytest.approx(1.0)
+        assert Q[0, 1] == pytest.approx(0.0)
+        assert Q[1, 1] == pytest.approx(0.0)
+
+    def test_nonlinear_raises(self):
+        x = Variable("x")
+        from optyx.core.errors import NonLinearError
+        with pytest.raises(NonLinearError):
+            extract_quadratic_coefficients(sin(x), [x])
+
+    def test_symmetry(self):
+        x = Variable("x")
+        y = Variable("y")
+        Q = extract_quadratic_coefficients(2 * x * y + x**2, [x, y])
+        np.testing.assert_array_almost_equal(Q, Q.T)
+
+
+# =============================================================================
+# Test VariableDict support
+# =============================================================================
+
+
+class TestVariableDictSupport:
+    """Tests for VariableDict LP export."""
+
+    def test_variable_dict_lp(self):
+        buy = VariableDict("buy", ["ham", "egg"], lb=0)
+        prob = Problem("diet")
+        prob.minimize(buy["ham"] + 2 * buy["egg"])
+        prob.subject_to(buy["ham"] + buy["egg"] >= 1)
+        lp = prob.to_lp()
+        assert "buy[ham]" in lp
+        assert "buy[egg]" in lp
+
+    def test_variable_dict_integer(self):
+        x = VariableDict("x", ["a", "b"], lb=0, ub=10, domain="integer")
+        prob = Problem()
+        prob.minimize(x["a"] + x["b"])
+        lp = prob.to_lp()
+        assert "Generals" in lp
+
+
+# =============================================================================
+# Test Round-Trip Accuracy
+# =============================================================================
+
+
+class TestRoundTrip:
+    """Tests verifying LP export matches the original model."""
+
+    def test_lp_objective_coefficients(self):
+        """Verify exported coefficients match the model."""
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        z = Variable("z", lb=0)
+        prob = Problem()
+        prob.minimize(5 * x - 3 * y + 7 * z)
+        lp = prob.to_lp()
+        assert "5 x" in lp
+        assert "- 3 y" in lp
+        assert "+ 7 z" in lp
+
+    def test_constraint_rhs(self):
+        """Verify constraint RHS values."""
+        x = Variable("x", lb=0)
+        y = Variable("y", lb=0)
+        prob = Problem()
+        prob.minimize(x + y)
+        prob.subject_to(x + y >= 10)
+        prob.subject_to(x - y <= 3)
+        lp = prob.to_lp()
+        assert ">= 10" in lp
+        assert "<= 3" in lp
+
+    def test_write_and_read_back(self, tmp_path):
+        """Verify file can be written and read back."""
+        x = Variable("x", lb=0, ub=100)
+        y = Variable("y", lb=-5, ub=50)
+        prob = Problem("roundtrip")
+        prob.minimize(2 * x + 3 * y)
+        prob.subject_to(x + y >= 1)
+        prob.subject_to(x - y <= 10)
+
+        filepath = str(tmp_path / "roundtrip.lp")
+        prob.write(filepath)
+
+        with open(filepath) as f:
+            content = f.read()
+
+        assert "\\ Model roundtrip" in content
+        assert "Minimize" in content
+        assert "Subject To" in content
+        assert "Bounds" in content
+        assert "End" in content
+
+    def test_maximize_objective(self):
+        x = Variable("x", lb=0, ub=10)
+        y = Variable("y", lb=0, ub=10)
+        prob = Problem()
+        prob.maximize(3 * x + 5 * y)
+        prob.subject_to(x + y <= 10)
+        lp = prob.to_lp()
+        assert "Maximize" in lp
+        assert "3 x" in lp
+        assert "5 y" in lp


### PR DESCRIPTION
## Summary

Implements LP format export for optimization problems, enabling users to write problems in standard CPLEX LP format.

## Changes

### New Files
- **`src/optyx/io.py`** — LP format export module with `write_lp()`, `format_lp()`, and internal formatting functions
- **`tests/test_lp_export.py`** — 59 tests covering all export functionality
- **`examples/lp_export.py`** — Demo with 5 examples (LP, QP, portfolio, MIP, file write)
- **`docs/examples/lp-export.qmd`** — Quarto documentation page

### Modified Files
- **`src/optyx/problem.py`** — Added `Problem.write(filename)` and `Problem.to_lp()` methods
- **`src/optyx/analysis.py`** — Added `extract_quadratic_coefficients()` utility
- **`docs/_quarto.yml`** — Added LP Export to navigation

## Features
- `Problem.write("file.lp")` — export to LP file
- `Problem.to_lp()` — return LP format as string
- Supports linear, quadratic (QP), and mixed-integer (MIP) problems
- Handles `QuadraticForm`, `DotProduct`, `var*var`, `expr**2` quadratic terms
- Correct `[ Q ] / 2` notation for quadratic objectives
- `Generals` / `Binaries` sections for integer/binary variables
- Matrix constraints (dense and sparse)
- `extract_quadratic_coefficients()` returns symmetric Q matrix

## Testing
- 59 new tests, all passing
- Full suite: 1253 tests passing

Closes #106