### PR TITLE
Fix LP extraction for sliced matrix sums

### DIFF
--- a/src/optyx/core/vectors.py
+++ b/src/optyx/core/vectors.py
@@ -1316,6 +1316,15 @@ class VectorVariable:
         ) and variable.ub == self._bound_at(self.ub, index)
 
     def _iter_variable_names(self) -> Iterator[str]:
+        cache = self._variable_cache
+        if cache is not None:
+            for index, variable in enumerate(cache):
+                if variable is not None:
+                    yield variable.name
+                else:
+                    yield self._name_at(index)
+            return
+
         for index in range(self.size):
             yield self._name_at(index)
 

--- a/tests/test_solver_integration.py
+++ b/tests/test_solver_integration.py
@@ -239,6 +239,35 @@ class TestMatrixVariableSolverIntegration:
         # Should be symmetric
         assert S_vals[0, 1] == pytest.approx(S_vals[1, 0], abs=1e-6)
 
+    def test_matrix_transport_problem_with_row_and_column_sums(self):
+        """Matrix row and column slice sums should produce a feasible LP."""
+        supply = np.array([100, 150, 200])
+        demand = np.array([80, 120, 100, 150])
+        costs = np.array(
+            [
+                [4, 6, 9, 5],
+                [5, 3, 7, 8],
+                [6, 8, 4, 3],
+            ]
+        )
+
+        ship = MatrixVariable("ship", 3, 4, lb=0)
+        total_cost = sum(costs[i, j] * ship[i, j] for i in range(3) for j in range(4))
+
+        prob = Problem("transport").minimize(total_cost)
+        for i in range(3):
+            prob = prob.subject_to(ship[i, :].sum() <= supply[i])
+        for j in range(4):
+            prob = prob.subject_to(ship[:, j].sum().eq(demand[j]))
+
+        sol = prob.solve()
+
+        assert sol.is_optimal
+        ship_vals = sol[ship]
+        np.testing.assert_allclose(ship_vals.sum(axis=1) <= supply + 1e-8, True)
+        np.testing.assert_allclose(ship_vals.sum(axis=0), demand, atol=1e-8)
+        assert sol.objective_value is not None
+
 
 # =============================================================================
 # Mixed Variable Types Tests


### PR DESCRIPTION
## Summary
Fix LP extraction for `MatrixVariable` row and column slice sums so transport-style linear programs build correct constraint rows and solve successfully.

## What changed
- make sliced `VectorVariable` instances yield backing scalar variable names during LP coefficient extraction
- add a regression test covering the matrix transport example with row-sum and column-sum constraints

## Validation
- `uv run pytest tests/test_solver_integration.py -k transport -q`
- `uv run pytest tests/test_solver_integration.py -k 'transport or matrix' -q`
- `uv run quarto render docs/`
